### PR TITLE
Run browser example build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Run project checks
         run: deno task check
+
+      - name: Build browser example bundle
+        run: deno task example:browser:build


### PR DESCRIPTION
## Summary
- add a dedicated CI step for deno task example:browser:build
- keep existing project checks unchanged and fail CI if browser bundling breaks

## Testing
- deno task check
- deno task example:browser:build

Closes #23