### PR TITLE
Improve documentation navigation across docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ The repository is organized as a Deno workspace with packages for:
 
 The design source of truth lives in [`docs/specs`](./docs/specs) and [`docs/adr`](./docs/adr).
 
+## Documentation Map
+
+- Start at [`docs/README.md`](./docs/README.md) for a guided index across architecture, runtime,
+  schema, and contributor references.
+- Browse [`docs/specs/README.md`](./docs/specs/README.md) for design and behavior specifications.
+- Browse [`docs/adr/README.md`](./docs/adr/README.md) for accepted architectural decisions.
+- Browse [`examples/README.md`](./examples/README.md) for runnable example entry points.
+
 ## Status
 
 This is an initial scaffold that establishes package boundaries, Scene IR, residency separation,
@@ -29,9 +37,20 @@ Implemented today:
 - browser canvas example and PNG snapshot encoding
 - device-loss observation and residency rebuild helpers
 
+## Quick Start
+
+Read in this order when onboarding:
+
+1. [`docs/specs/architecture.md`](./docs/specs/architecture.md)
+2. [`docs/specs/scene-ir.md`](./docs/specs/scene-ir.md)
+3. [`docs/specs/runtime-residency.md`](./docs/specs/runtime-residency.md)
+4. [`docs/specs/rendering.md`](./docs/specs/rendering.md)
+5. [`examples/browser_forward/README.md`](./examples/browser_forward/README.md)
+
 ## Tasks
 
 - `deno task check`: format, codegen drift check, lint, test, and bench preflight
+- `deno task docs:check`: format-check docs, packages, tests, benches, and examples content
 - `deno task generate:ir`: regenerate TypeScript from BDL IR
 - `deno task generate:ir:check`: fail when generated IR files are stale
 - `deno task example:browser:build`: bundle the browser forward-rendering example

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Documentation
+
+This repository keeps design intent, accepted decisions, and runnable workflows in separate folders.
+Use this page as the main navigation hub.
+
+## Read By Goal
+
+- Understand the system shape: [`specs/architecture.md`](./specs/architecture.md)
+- Understand the scene data model: [`specs/scene-ir.md`](./specs/scene-ir.md)
+- Understand runtime GPU ownership and recovery:
+  [`specs/runtime-residency.md`](./specs/runtime-residency.md)
+- Understand current rendering scope and gaps: [`specs/rendering.md`](./specs/rendering.md)
+- Understand loader and interchange direction: [`specs/interop-gltf.md`](./specs/interop-gltf.md)
+- Understand authoring boundaries: [`specs/react-authoring.md`](./specs/react-authoring.md)
+- Review accepted architecture constraints: [`adr/README.md`](./adr/README.md)
+- Run the existing browser example: [`../examples/README.md`](../examples/README.md)
+
+## Contributor Workflows
+
+- Repository entry point: [`../README.md`](../README.md)
+- Code style and repository conventions: [`specs/coding-style.md`](./specs/coding-style.md)
+- Verification task bundle: `deno task check`
+- Docs and formatting verification: `deno task docs:check`
+
+## Directory Guide
+
+- [`specs/README.md`](./specs/README.md): design docs and behavioral contracts
+- [`adr/README.md`](./adr/README.md): short decision records for accepted constraints
+- [`../examples/README.md`](../examples/README.md): runnable example entry points and commands

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# ADR Index
+
+Architectural decision records capture constraints that should stay stable unless a new decision
+supersedes them.
+
+## Accepted Decisions
+
+- [`0001-webgpu-only.md`](./0001-webgpu-only.md): WebGPU is the only rendering backend
+- [`0002-bdl-scene-ir.md`](./0002-bdl-scene-ir.md): Scene IR is authored through BDL and generated
+  types
+- [`0003-functional-first.md`](./0003-functional-first.md): public APIs stay data-oriented and
+  functional-first
+
+## Related References
+
+- [`../specs/architecture.md`](../specs/architecture.md): package and runtime layering
+- [`../specs/scene-ir.md`](../specs/scene-ir.md): data schema expectations
+- [`../README.md`](../README.md): docs landing page

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,22 @@
+# Specifications
+
+These documents describe the intended architecture and current runtime behavior. Read them as the
+source of truth for package boundaries and feature expectations.
+
+## Architecture And Data
+
+- [`architecture.md`](./architecture.md): top-level runtime layers and package responsibilities
+- [`scene-ir.md`](./scene-ir.md): serializable scene schema and lowering expectations
+- [`interop-gltf.md`](./interop-gltf.md): interchange strategy for Blender, glTF, OBJ, and STL
+
+## Runtime Behavior
+
+- [`runtime-residency.md`](./runtime-residency.md): device-local resource ownership and rebuild
+  rules
+- [`rendering.md`](./rendering.md): renderer families, pass model, shader model, and current gaps
+- [`react-authoring.md`](./react-authoring.md): React package role and lowering boundaries
+
+## Contributor Reference
+
+- [`coding-style.md`](./coding-style.md): code and API style guidance for contributors
+- [`../README.md`](../README.md): docs landing page

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# Examples
+
+Runnable examples live here. Each example should document how to build, serve, or execute it.
+
+## Available Examples
+
+- [`browser_forward/README.md`](./browser_forward/README.md): browser-based forward rendering flow
+
+## Common Commands
+
+- Build the browser bundle: `deno task example:browser:build`
+- Serve the repository for local testing: `deno task example:browser:serve`
+
+## Related Docs
+
+- [`../docs/README.md`](../docs/README.md): main documentation hub
+- [`../docs/specs/rendering.md`](../docs/specs/rendering.md): rendering contracts and current gaps

--- a/examples/browser_forward/README.md
+++ b/examples/browser_forward/README.md
@@ -1,5 +1,7 @@
 # Browser Forward Example
 
+This is the main runnable example for the current renderer scaffold.
+
 Build the example bundle:
 
 ```sh
@@ -17,3 +19,9 @@ Then open:
 ```text
 http://localhost:8000/examples/browser_forward/index.html
 ```
+
+Related references:
+
+- [`../../examples/README.md`](../README.md)
+- [`../../docs/specs/rendering.md`](../../docs/specs/rendering.md)
+- [`../../docs/specs/runtime-residency.md`](../../docs/specs/runtime-residency.md)


### PR DESCRIPTION
## Summary
- add a docs landing page that groups specs, ADRs, examples, and contributor workflows
- add README indexes for specs, ADRs, and examples so readers can navigate folders directly
- expand the root README and browser example README with quick-start and related links

Closes #31