### PR TITLE
Document device-loss recovery contract and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Implemented today:
 - Rendering contracts: [`docs/specs/rendering.md`](./docs/specs/rendering.md)
 - Renderer capability model:
   [`docs/specs/renderer-capabilities.md`](./docs/specs/renderer-capabilities.md)
+- Device-loss recovery contract:
+  [`docs/specs/device-loss-recovery.md`](./docs/specs/device-loss-recovery.md)
 - Runtime residency and rebuild rules:
   [`docs/specs/runtime-residency.md`](./docs/specs/runtime-residency.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Use this page as the main navigation hub.
 - Understand the scene data model: [`specs/scene-ir.md`](./specs/scene-ir.md)
 - Understand runtime GPU ownership and recovery:
   [`specs/runtime-residency.md`](./specs/runtime-residency.md)
+- Understand device-loss handling and caller recovery steps:
+  [`specs/device-loss-recovery.md`](./specs/device-loss-recovery.md)
 - Understand current rendering scope and gaps: [`specs/rendering.md`](./specs/rendering.md)
 - Understand loader and interchange direction: [`specs/interop-gltf.md`](./specs/interop-gltf.md)
 - Understand authoring boundaries: [`specs/react-authoring.md`](./specs/react-authoring.md)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,6 +11,8 @@ source of truth for package boundaries and feature expectations.
 
 ## Runtime Behavior
 
+- [`device-loss-recovery.md`](./device-loss-recovery.md): explicit device-loss recovery sequence and
+  caller responsibilities
 - [`runtime-residency.md`](./runtime-residency.md): device-local resource ownership and rebuild
   rules
 - [`rendering.md`](./rendering.md): renderer families, pass model, shader model, and current gaps

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -31,6 +31,8 @@ The runtime is split into explicit data and execution stages:
 - `packages/loaders`: format parsers that normalize input into Scene IR.
 - `packages/react`: declarative scene authoring that feeds the same IR/core pipeline.
 - `packages/platform`: target descriptors for browser, Deno, and headless execution.
+- device-loss recovery remains a caller-visible workflow rather than an implicit runtime reset. See
+  [`device-loss-recovery.md`](./device-loss-recovery.md).
 
 ## Current Runtime Surface
 
@@ -45,6 +47,7 @@ The current scaffold already includes:
 - browser surface binding and a bundled browser example
 - a Windows BYOW triangle example for native Deno surface presentation
 - device-loss observation and residency rebuild helpers
+- explicit device-loss recovery sequencing for device replacement and target rebinding
 - benchmark coverage for key runtime paths
 
 ## Design Constraints

--- a/docs/specs/device-loss-recovery.md
+++ b/docs/specs/device-loss-recovery.md
@@ -1,0 +1,87 @@
+# Device-Loss Recovery
+
+## Purpose
+
+This document defines the contract for reacting to WebGPU device loss in `rieul3d`. Recovery is
+explicit: callers own device replacement, target rebinding, residency rebuild, and the first frame
+submitted on the new device.
+
+## Recovery Entry Points
+
+- `observeDeviceLoss(device, onLost)` waits for `GPUDevice.lost`, normalizes the payload into
+  `GpuLostInfo`, and forwards it to the caller.
+- `rebuildRuntimeResidency(context, residency, scene, evaluatedScene, assetSource)` clears stale
+  device-local caches and recreates mesh, material, texture, and volume residency from CPU-owned
+  inputs.
+
+These helpers are intentionally small. They do not hide adapter/device negotiation or surface
+reconfiguration behind a global runtime singleton.
+
+## Ownership Rules
+
+- `SceneIr`, source assets, and evaluated scene results remain the source of truth.
+- `RuntimeResidency` is disposable device-local state.
+- Render target bindings are disposable device-local state.
+- Pipeline caches are disposable device-local state and are always dropped during rebuild.
+- The caller is responsible for holding onto enough CPU-side state to rebuild residency.
+
+## Recovery Sequence
+
+When a device is lost, callers should perform recovery in this order:
+
+1. Observe loss and stop submitting new work on the dead device.
+2. Request or construct a replacement `GPUDevice` and queue.
+3. Recreate the render target binding.
+4. Re-evaluate the scene if transforms, animation time, or authoring state changed since the last
+   frame.
+5. Call `rebuildRuntimeResidency(...)` with the replacement device/queue plus the current `SceneIr`,
+   evaluated scene, and asset source.
+6. Recreate any renderer-side objects that depend on the old device.
+7. Submit a new frame explicitly.
+
+`rebuildRuntimeResidency(...)` only restores residency caches. It does not implicitly redraw.
+
+## Disposable vs Persistent State
+
+| State                               | Owner                | After loss                |
+| ----------------------------------- | -------------------- | ------------------------- |
+| `SceneIr`                           | caller               | keep                      |
+| image/volume asset bytes + metadata | caller               | keep                      |
+| evaluated scene snapshot            | caller               | keep or recompute         |
+| `RuntimeResidency.geometry`         | runtime residency    | rebuild                   |
+| `RuntimeResidency.materials`        | runtime residency    | rebuild                   |
+| `RuntimeResidency.textures`         | runtime residency    | rebuild                   |
+| `RuntimeResidency.volumes`          | runtime residency    | rebuild                   |
+| `RuntimeResidency.pipelines`        | runtime residency    | clear and lazily recreate |
+| surface/offscreen target binding    | caller + GPU context | recreate                  |
+
+## Caller Responsibilities
+
+- Keep the latest asset source reachable for rebuild.
+- Keep or recompute the evaluated scene before rebuild.
+- Rebind browser canvases or recreate offscreen targets on the replacement device.
+- Treat the first post-recovery frame as a normal render submission that must be requested
+  explicitly.
+- Surface recovery failure if replacement device creation or residency rebuild throws.
+
+## Failure Model
+
+- `observeDeviceLoss(...)` reports the platform-provided reason and message, but does not interpret
+  whether the device can be recovered.
+- `rebuildRuntimeResidency(...)` throws if required image or volume assets are missing or
+  incomplete.
+- If rebuild fails, callers should keep the runtime in a non-rendering state rather than reuse
+  partially rebuilt residency.
+
+## Current Scope
+
+Today the documented recovery contract covers:
+
+- mesh residency
+- material uniform residency
+- texture residency
+- volume residency
+- render pipeline cache invalidation
+
+Future renderer-specific transient resources can extend this contract, but they must follow the same
+rule: CPU-owned source data survives, device-local caches are recreated.

--- a/docs/specs/runtime-residency.md
+++ b/docs/specs/runtime-residency.md
@@ -39,3 +39,5 @@ from Scene IR so the same IR can run in browsers, Deno, and headless targets.
   `AssetSource + SceneIr + EvaluatedScene`.
 - Pipeline caches are considered disposable and are cleared during rebuild.
 - Device loss is observed explicitly rather than hidden behind global runtime state.
+- Callers still own replacement device creation, target rebinding, and the first rerender after
+  rebuild. See [`device-loss-recovery.md`](./device-loss-recovery.md) for the full sequence.


### PR DESCRIPTION
## Summary
- add a dedicated device-loss recovery contract covering ownership, rebuild order, and failure handling
- link the new recovery document from the docs landing page, spec index, runtime residency spec, and architecture overview
- surface the recovery guide from the root README documentation map

Closes #22