### PR TITLE
Support GLB and external URI glTF assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Implemented today:
 - forward rendering, first SDF raymarch execution, and headless snapshot readback
 - built-in unlit material registration, base-color texture sampling, material parameter uploads, and
   custom WGSL registration
+- glTF JSON, GLB, data-URI buffers, and caller-provided external glTF resource ingestion
 - browser canvas example, Windows BYOW triangle example, and PNG snapshot encoding
 - device-loss observation and residency rebuild helpers
 - renderer capability preflight for primitive and material compatibility

--- a/docs/specs/interop-gltf.md
+++ b/docs/specs/interop-gltf.md
@@ -17,12 +17,20 @@ Blender interoperability is `glTF-first`. The primary interchange path is:
 
 ## Current Status
 
-- The current glTF path ingests JSON scenes, data-URI buffers, bufferViews, accessors, images,
-  textures, materials, meshes, nodes, and animations into Scene IR.
+- The current glTF path ingests JSON scenes, GLB containers, data-URI buffers, bufferViews,
+  accessors, images, textures, materials, meshes, nodes, and animations into Scene IR.
 - Runtime support behind the loader includes mesh, texture, material, forward rendering, headless
   snapshotting, and first volume residency paths.
-- GLB containers and external file URIs are still out of scope; the loader currently expects inline
-  data for binary payloads.
+- External buffer and image URIs are supported when callers provide the referenced bytes through
+  `loadGltfFromJson(..., { baseUri, resources })`.
+
+## Loader Notes
+
+- `loadGltfFromJson` remains synchronous. External binary payloads must be resolved by the caller
+  ahead of time and passed through `resources`.
+- `loadGltfFromGlb` parses glTF 2.0 GLB containers and uses the embedded BIN chunk for buffer data.
+- External image URIs are normalized against `baseUri` and preserved on emitted `SceneIr.assets`
+  entries so runtime-side asset loading can still occur later.
 
 ## Other Formats
 

--- a/packages/loaders/src/gltf.ts
+++ b/packages/loaders/src/gltf.ts
@@ -84,13 +84,6 @@ type GltfNode = Readonly<{
   children?: readonly number[];
 }>;
 
-type LegacyAnimationChannel = Readonly<{
-  node: number;
-  path: string;
-  times: readonly number[];
-  values: readonly (readonly number[])[];
-}>;
-
 type GltfAnimationSampler = Readonly<{
   input: number;
   output: number;
@@ -131,6 +124,24 @@ type GltfJson = Readonly<{
   scene?: number;
   animations?: readonly GltfAnimation[];
 }>;
+
+export type GltfLoadOptions = Readonly<{
+  baseUri?: string;
+  resources?: Readonly<Record<string, Uint8Array>>;
+}>;
+
+type ResolvedResource = Readonly<{
+  uri: string;
+  bytes?: Uint8Array;
+}>;
+
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const GLB_JSON_CHUNK = 0x4e4f534a;
+const GLB_BIN_CHUNK = 0x004e4942;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 const accessorItemSize = (type: GltfAccessorType): number => {
   switch (type) {
@@ -173,7 +184,7 @@ const decodeDataUri = (uri: string): Uint8Array => {
     return Uint8Array.from(binary, (character) => character.charCodeAt(0));
   }
 
-  return new TextEncoder().encode(decodeURIComponent(payload));
+  return textEncoder.encode(decodeURIComponent(payload));
 };
 
 const inferDataUriMimeType = (uri: string): string | undefined => {
@@ -186,55 +197,187 @@ const inferDataUriMimeType = (uri: string): string | undefined => {
   return mimeType.length === 0 ? undefined : mimeType;
 };
 
-const getBufferBytes = (buffer: GltfBuffer, sceneId: string, bufferIndex: number): Uint8Array => {
-  if (!buffer.uri) {
-    throw new Error(
-      `glTF buffer ${bufferIndex} in "${sceneId}" does not provide a uri; GLB buffers are not supported yet`,
-    );
-  }
-
-  if (!buffer.uri.startsWith('data:')) {
-    throw new Error(
-      `glTF buffer ${bufferIndex} in "${sceneId}" uses an external uri; only data URIs are supported right now`,
-    );
-  }
-
-  return decodeDataUri(buffer.uri);
-};
-
-const getImageBytes = (
-  image: GltfImage,
-  buffers: readonly Uint8Array[],
-  bufferViews: readonly GltfBufferView[],
-  sceneId: string,
-  imageIndex: number,
-): Uint8Array | undefined => {
-  if (image.uri) {
-    if (!image.uri.startsWith('data:')) {
-      throw new Error(
-        `glTF image ${imageIndex} in "${sceneId}" uses an external uri; only data URIs are supported right now`,
-      );
-    }
-
-    return decodeDataUri(image.uri);
-  }
-
-  if (image.bufferView === undefined) {
+const inferMimeTypeFromUri = (uri: string): string | undefined => {
+  const path = uri.split('?')[0]?.split('#')[0] ?? uri;
+  const extensionIndex = path.lastIndexOf('.');
+  if (extensionIndex < 0) {
     return undefined;
   }
 
-  const bufferView = bufferViews[image.bufferView];
+  switch (path.slice(extensionIndex + 1).toLowerCase()) {
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'webp':
+      return 'image/webp';
+    case 'ktx2':
+      return 'image/ktx2';
+    default:
+      return undefined;
+  }
+};
+
+const resolveUri = (uri: string, baseUri?: string): string => {
+  if (!baseUri) {
+    return uri;
+  }
+
+  try {
+    return new URL(uri, baseUri).toString();
+  } catch {
+    return uri;
+  }
+};
+
+const resolveResource = (
+  uri: string,
+  options: GltfLoadOptions,
+): ResolvedResource => {
+  const resolvedUri = resolveUri(uri, options.baseUri);
+  const bytes = options.resources?.[resolvedUri] ?? options.resources?.[uri];
+  return { uri: resolvedUri, bytes };
+};
+
+const sliceBufferView = (
+  buffers: readonly Uint8Array[],
+  bufferViews: readonly GltfBufferView[],
+  bufferViewIndex: number,
+  label: string,
+): Uint8Array => {
+  const bufferView = bufferViews[bufferViewIndex];
   if (!bufferView) {
-    throw new Error(`glTF image ${imageIndex} references missing bufferView ${image.bufferView}`);
+    throw new Error(`${label} references missing bufferView ${bufferViewIndex}`);
   }
 
   const bytes = buffers[bufferView.buffer];
   if (!bytes) {
-    throw new Error(`glTF image ${imageIndex} references missing buffer ${bufferView.buffer}`);
+    throw new Error(`${label} references missing buffer ${bufferView.buffer}`);
   }
 
   const byteOffset = bufferView.byteOffset ?? 0;
   return bytes.slice(byteOffset, byteOffset + bufferView.byteLength);
+};
+
+const parseGlb = (glbBytes: Uint8Array): { json: GltfJson; binaryChunk?: Uint8Array } => {
+  const headerLength = 12;
+  if (glbBytes.byteLength < headerLength) {
+    throw new Error('GLB payload is too short to contain a valid header');
+  }
+
+  const view = new DataView(glbBytes.buffer, glbBytes.byteOffset, glbBytes.byteLength);
+  const magic = view.getUint32(0, true);
+  const version = view.getUint32(4, true);
+  const length = view.getUint32(8, true);
+
+  if (magic !== GLB_MAGIC) {
+    throw new Error('GLB payload is missing the glTF magic header');
+  }
+
+  if (version !== GLB_VERSION) {
+    throw new Error(`GLB version ${version} is not supported`);
+  }
+
+  if (length !== glbBytes.byteLength) {
+    throw new Error(
+      `GLB declared length ${length} does not match payload length ${glbBytes.byteLength}`,
+    );
+  }
+
+  let offset = headerLength;
+  let json: GltfJson | undefined;
+  let binaryChunk: Uint8Array | undefined;
+
+  while (offset + 8 <= glbBytes.byteLength) {
+    const chunkLength = view.getUint32(offset, true);
+    const chunkType = view.getUint32(offset + 4, true);
+    offset += 8;
+
+    if (offset + chunkLength > glbBytes.byteLength) {
+      throw new Error('GLB chunk length exceeds the payload length');
+    }
+
+    const chunkBytes = glbBytes.slice(offset, offset + chunkLength);
+    if (chunkType === GLB_JSON_CHUNK) {
+      json = JSON.parse(textDecoder.decode(chunkBytes).replace(/\0+$/u, '').trimEnd()) as GltfJson;
+    } else if (chunkType === GLB_BIN_CHUNK && binaryChunk === undefined) {
+      binaryChunk = chunkBytes;
+    }
+
+    offset += chunkLength;
+  }
+
+  if (!json) {
+    throw new Error('GLB payload does not contain a JSON chunk');
+  }
+
+  return { json, binaryChunk };
+};
+
+const getBufferBytes = (
+  buffer: GltfBuffer,
+  sceneId: string,
+  bufferIndex: number,
+  options: GltfLoadOptions,
+  binaryChunk?: Uint8Array,
+): Uint8Array => {
+  if (!buffer.uri) {
+    if (binaryChunk) {
+      return binaryChunk.slice(0, buffer.byteLength);
+    }
+
+    throw new Error(
+      `glTF buffer ${bufferIndex} in "${sceneId}" does not provide a uri and no GLB binary chunk was supplied`,
+    );
+  }
+
+  if (buffer.uri.startsWith('data:')) {
+    return decodeDataUri(buffer.uri);
+  }
+
+  const resource = resolveResource(buffer.uri, options);
+  if (!resource.bytes) {
+    throw new Error(
+      `glTF buffer ${bufferIndex} in "${sceneId}" uses external uri "${resource.uri}" without provided bytes`,
+    );
+  }
+
+  return resource.bytes;
+};
+
+const getImageResource = (
+  image: GltfImage,
+  buffers: readonly Uint8Array[],
+  bufferViews: readonly GltfBufferView[],
+  options: GltfLoadOptions,
+  sceneId: string,
+  imageIndex: number,
+): ResolvedResource => {
+  if (image.uri) {
+    if (image.uri.startsWith('data:')) {
+      return {
+        uri: image.uri,
+        bytes: decodeDataUri(image.uri),
+      };
+    }
+
+    return resolveResource(image.uri, options);
+  }
+
+  if (image.bufferView === undefined) {
+    return { uri: `${sceneId}-image-${imageIndex}` };
+  }
+
+  return {
+    uri: `${sceneId}-image-${imageIndex}`,
+    bytes: sliceBufferView(
+      buffers,
+      bufferViews,
+      image.bufferView,
+      `glTF image ${imageIndex}`,
+    ),
+  };
 };
 
 const readComponent = (
@@ -358,6 +501,7 @@ const createTextureRefs = (
   sceneId: string,
   json: GltfJson,
   buffers: readonly Uint8Array[],
+  options: GltfLoadOptions,
 ): { assets: AssetRef[]; textures: TextureRef[] } => {
   const assets: AssetRef[] = [];
   const textures: TextureRef[] = [];
@@ -371,18 +515,20 @@ const createTextureRefs = (
     if (imageIndex !== undefined && image) {
       assetId = `${sceneId}-image-${imageIndex}`;
       if (!assets.some((asset) => asset.id === assetId)) {
-        const imageBytes = getImageBytes(
+        const resource = getImageResource(
           image,
           buffers,
           json.bufferViews ?? [],
+          options,
           sceneId,
           imageIndex,
         );
         assets.push({
           id: assetId,
-          uri: image.uri,
+          uri: image.uri ? resource.uri : undefined,
           mimeType: image.mimeType ?? inferDataUriMimeType(image.uri ?? '') ??
-            (imageBytes ? 'application/octet-stream' : undefined),
+            inferMimeTypeFromUri(resource.uri) ??
+            (resource.bytes ? 'application/octet-stream' : undefined),
         });
       }
     }
@@ -501,16 +647,18 @@ const createAnimationClips = (
     };
   });
 
-export const loadGltfFromJson = (
+const loadGltfScene = (
   json: GltfJson,
-  sceneId = 'gltf-scene',
+  sceneId: string,
+  options: GltfLoadOptions,
+  binaryChunk?: Uint8Array,
 ): SceneIr => {
   const nodes = json.nodes ?? [];
   const buffers = (json.buffers ?? []).map((buffer, bufferIndex) =>
-    getBufferBytes(buffer, sceneId, bufferIndex)
+    getBufferBytes(buffer, sceneId, bufferIndex, options, binaryChunk)
   );
   const parentIds = buildParentIds(sceneId, nodes);
-  const { assets, textures } = createTextureRefs(sceneId, json, buffers);
+  const { assets, textures } = createTextureRefs(sceneId, json, buffers, options);
   const materials = createMaterials(sceneId, json, textures);
   const rootNodeIds = getDefaultRootIndices(json).map((nodeIndex) =>
     `${sceneId}-node-${nodeIndex}`
@@ -582,4 +730,19 @@ export const loadGltfFromJson = (
   }
 
   return scene;
+};
+
+export const loadGltfFromJson = (
+  json: GltfJson,
+  sceneId = 'gltf-scene',
+  options: GltfLoadOptions = {},
+): SceneIr => loadGltfScene(json, sceneId, options);
+
+export const loadGltfFromGlb = (
+  glbBytes: Uint8Array,
+  sceneId = 'gltf-scene',
+  options: GltfLoadOptions = {},
+): SceneIr => {
+  const { json, binaryChunk } = parseGlb(glbBytes);
+  return loadGltfScene(json, sceneId, options, binaryChunk);
 };

--- a/tests/loaders_test.ts
+++ b/tests/loaders_test.ts
@@ -1,5 +1,12 @@
 import { assertEquals } from 'jsr:@std/assert@^1.0.14';
-import { loadGltfFromJson, loadObjFromText, loadStlFromText } from '@rieul3d/loaders';
+import {
+  loadGltfFromGlb,
+  loadGltfFromJson,
+  loadObjFromText,
+  loadStlFromText,
+} from '@rieul3d/loaders';
+
+const textEncoder = new TextEncoder();
 
 const encodeDataUri = (bytes: Uint8Array, mimeType = 'application/octet-stream'): string => {
   const binary = Array.from(bytes, (value) => String.fromCharCode(value)).join('');
@@ -17,6 +24,35 @@ const concatBytes = (...parts: Uint8Array[]): Uint8Array => {
   }
 
   return bytes;
+};
+
+const alignTo4 = (value: number): number => (value + 3) & ~3;
+
+const createGlb = (json: unknown, binaryChunk: Uint8Array): Uint8Array => {
+  const jsonBytes = textEncoder.encode(JSON.stringify(json));
+  const paddedJsonLength = alignTo4(jsonBytes.byteLength);
+  const paddedBinaryLength = alignTo4(binaryChunk.byteLength);
+  const totalLength = 12 + 8 + paddedJsonLength + 8 + paddedBinaryLength;
+  const glb = new Uint8Array(totalLength);
+  const view = new DataView(glb.buffer);
+  const paddedJson = new Uint8Array(paddedJsonLength);
+  const paddedBinary = new Uint8Array(paddedBinaryLength);
+
+  paddedJson.set(jsonBytes);
+  paddedJson.fill(0x20, jsonBytes.byteLength);
+  paddedBinary.set(binaryChunk);
+
+  view.setUint32(0, 0x46546c67, true);
+  view.setUint32(4, 2, true);
+  view.setUint32(8, totalLength, true);
+  view.setUint32(12, paddedJsonLength, true);
+  view.setUint32(16, 0x4e4f534a, true);
+  glb.set(paddedJson, 20);
+  view.setUint32(20 + paddedJsonLength, paddedBinaryLength, true);
+  view.setUint32(24 + paddedJsonLength, 0x004e4942, true);
+  glb.set(paddedBinary, 28 + paddedJsonLength);
+
+  return glb;
 };
 
 Deno.test('loadObjFromText builds a mesh scene', () => {
@@ -204,4 +240,132 @@ Deno.test('loadGltfFromJson ingests buffer views, accessors, images, and materia
     z: 0,
     w: 0,
   });
+});
+
+Deno.test('loadGltfFromJson resolves external buffer and image URIs from provided resources', () => {
+  const positions = new Float32Array([
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    1,
+    0,
+  ]);
+  const externalBuffer = new Uint8Array(positions.buffer);
+  const scene = loadGltfFromJson(
+    {
+      buffers: [{
+        uri: 'geometry.bin',
+        byteLength: externalBuffer.byteLength,
+      }],
+      bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: externalBuffer.byteLength }],
+      accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3' }],
+      images: [{
+        uri: 'textures/albedo.png',
+      }],
+      textures: [{ source: 0 }],
+      materials: [{
+        pbrMetallicRoughness: {
+          baseColorTexture: { index: 0 },
+        },
+      }],
+      meshes: [{
+        primitives: [{
+          attributes: {
+            POSITION: 0,
+          },
+          material: 0,
+        }],
+      }],
+      nodes: [{ mesh: 0 }],
+      scenes: [{ nodes: [0] }],
+      scene: 0,
+    },
+    'external',
+    {
+      baseUri: 'https://example.test/models/scene.gltf',
+      resources: {
+        'https://example.test/models/geometry.bin': externalBuffer,
+      },
+    },
+  );
+
+  assertEquals(scene.meshes[0].attributes[0].values, [0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  assertEquals(scene.assets, [{
+    id: 'external-image-0',
+    uri: 'https://example.test/models/textures/albedo.png',
+    mimeType: 'image/png',
+  }]);
+});
+
+Deno.test('loadGltfFromGlb ingests binary buffers and bufferView-backed images', () => {
+  const positions = new Float32Array([
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    1,
+    0,
+  ]);
+  const indices = new Uint16Array([0, 1, 2]);
+  const imageBytes = new Uint8Array([137, 80, 78, 71]);
+  const positionBytes = new Uint8Array(positions.buffer);
+  const indexBytes = new Uint8Array(indices.buffer);
+  const glbBinary = concatBytes(positionBytes, indexBytes, imageBytes);
+  const glb = createGlb({
+    asset: { version: '2.0' },
+    buffers: [{ byteLength: glbBinary.byteLength }],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: positionBytes.byteLength },
+      { buffer: 0, byteOffset: positionBytes.byteLength, byteLength: indexBytes.byteLength },
+      {
+        buffer: 0,
+        byteOffset: positionBytes.byteLength + indexBytes.byteLength,
+        byteLength: imageBytes.byteLength,
+      },
+    ],
+    accessors: [
+      { bufferView: 0, componentType: 5126, count: 3, type: 'VEC3' },
+      { bufferView: 1, componentType: 5123, count: 3, type: 'SCALAR' },
+    ],
+    images: [{
+      bufferView: 2,
+      mimeType: 'image/png',
+    }],
+    textures: [{ source: 0 }],
+    materials: [{
+      pbrMetallicRoughness: {
+        baseColorTexture: { index: 0 },
+      },
+    }],
+    meshes: [{
+      primitives: [{
+        attributes: {
+          POSITION: 0,
+        },
+        indices: 1,
+        material: 0,
+      }],
+    }],
+    nodes: [{ mesh: 0 }],
+    scenes: [{ nodes: [0] }],
+    scene: 0,
+  }, glbBinary);
+
+  const scene = loadGltfFromGlb(glb, 'glb');
+
+  assertEquals(scene.meshes[0].indices, [0, 1, 2]);
+  assertEquals(scene.meshes[0].attributes[0].values, [0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  assertEquals(scene.assets, [{
+    id: 'glb-image-0',
+    uri: undefined,
+    mimeType: 'image/png',
+  }]);
+  assertEquals(scene.materials[0].textures, [scene.textures[0]]);
 });


### PR DESCRIPTION
## Summary
- add `loadGltfFromGlb` and extend `loadGltfFromJson` with caller-provided external resource resolution
- support GLB BIN chunks plus external buffer/image URIs in the glTF loader
- add regression tests and update README + glTF interop docs

## Testing
- deno test --unstable-raw-imports tests/loaders_test.ts
- deno task check
- deno task docs:check

Closes #28