### PR TITLE
Add richer BYOW native demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Implemented today:
 - built-in unlit material registration, base-color texture sampling, material parameter uploads, and
   custom WGSL registration
 - glTF JSON, GLB, data-URI buffers, and caller-provided external glTF resource ingestion
-- browser canvas example, Windows BYOW triangle example, and PNG snapshot encoding
+- browser canvas example, Windows BYOW native textured demo, and PNG snapshot encoding
 - device-loss observation and residency rebuild helpers
 - renderer capability preflight for primitive and material compatibility
 
@@ -60,6 +60,7 @@ Read in this order when onboarding:
 3. [`docs/specs/runtime-residency.md`](./docs/specs/runtime-residency.md)
 4. [`docs/specs/rendering.md`](./docs/specs/rendering.md)
 5. [`examples/browser_forward/README.md`](./examples/browser_forward/README.md)
+6. [`examples/byow_native_demo/README.md`](./examples/byow_native_demo/README.md)
 
 ## Tasks
 
@@ -70,5 +71,5 @@ Read in this order when onboarding:
 - `deno task setup:sdl2:windows`: download the official SDL2 Windows runtime for BYOW examples
 - `deno task example:browser:build`: bundle the browser forward-rendering example
 - `deno task example:browser:serve`: serve the repository for local browser testing
-- `deno task example:byow:check`: type-check the BYOW SDL2 triangle example
-- `deno task example:byow:run`: open the Windows BYOW triangle example
+- `deno task example:byow:check`: type-check the Windows BYOW native demo
+- `deno task example:byow:run`: open the Windows BYOW native demo

--- a/deno.json
+++ b/deno.json
@@ -28,8 +28,8 @@
     "bench": "deno bench --unstable-raw-imports",
     "docs:check": "deno fmt --check docs packages tests benches examples",
     "setup:sdl2:windows": "powershell -ExecutionPolicy Bypass -File ./scripts/install_sdl2_windows.ps1",
-    "example:byow:check": "deno check --unstable-ffi --unstable-webgpu --unstable-raw-imports ./examples/byow_triangle/main.ts",
-    "example:byow:run": "deno run -A --unstable-ffi --unstable-webgpu --unstable-raw-imports ./scripts/run_byow_triangle.ts",
+    "example:byow:check": "deno check --unstable-ffi --unstable-webgpu --unstable-raw-imports ./examples/byow_native_demo/main.ts",
+    "example:byow:run": "deno run -A --unstable-ffi --unstable-webgpu --unstable-raw-imports ./scripts/run_byow_native_demo.ts",
     "example:browser:build": "deno bundle --platform browser --unstable-raw-imports -o ./examples/browser_forward/dist/main.js ./examples/browser_forward/main.ts",
     "example:browser:serve": "deno run -A jsr:@std/http@1/file-server ."
   },

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Use this page as the main navigation hub.
 - Understand loader and interchange direction: [`specs/interop-gltf.md`](./specs/interop-gltf.md)
 - Understand authoring boundaries: [`specs/react-authoring.md`](./specs/react-authoring.md)
 - Review accepted architecture constraints: [`adr/README.md`](./adr/README.md)
-- Run the existing browser example: [`../examples/README.md`](../examples/README.md)
+- Run the browser and native examples: [`../examples/README.md`](../examples/README.md)
 
 ## Contributor Workflows
 

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -43,6 +43,8 @@ The initial renderer uses a lightweight pass graph:
 - Custom WGSL programs can be registered and cached through the material registry.
 - Headless/offscreen rendering supports compact byte readback for snapshot testing.
 - Snapshot bytes can also be encoded into PNG for local inspection and regression workflows.
+- The native BYOW demo uses the same forward renderer/runtime residency path on an SDL2-backed
+  surface target instead of a browser canvas.
 
 ## Known Gaps
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,10 +4,14 @@ Runnable examples live here. Each example should document how to build, serve, o
 
 ## Available Examples
 
+- [`byow_native_demo/README.md`](./byow_native_demo/README.md): Windows-native BYOW surface demo
+  using runtime mesh, texture residency, and built-in textured unlit rendering
 - [`browser_forward/README.md`](./browser_forward/README.md): browser-based forward rendering flow
 
 ## Common Commands
 
+- Run the native BYOW demo: `deno task example:byow:run`
+- Type-check the native BYOW demo: `deno task example:byow:check`
 - Build the browser bundle: `deno task example:browser:build`
 - Serve the repository for local testing: `deno task example:browser:serve`
 

--- a/examples/byow_native_demo/README.md
+++ b/examples/byow_native_demo/README.md
@@ -1,0 +1,36 @@
+# BYOW Native Demo
+
+Windows-native BYOW example using SDL2 and `Deno.UnsafeWindowSurface`.
+
+This demo exercises more of the `rieul3d` runtime than the startup triangle by rendering:
+
+- an indexed quad through the built-in textured unlit path
+- an additional accent mesh with a separate material
+- a native WebGPU surface presented through SDL2 on Windows
+
+Run with:
+
+```sh
+deno task setup:sdl2:windows
+deno task example:byow:run
+```
+
+Type-check with:
+
+```sh
+deno task example:byow:check
+```
+
+Expected output:
+
+- a tiled checkerboard panel on the left side of the window
+- an orange accent triangle on the right side
+
+Requirements:
+
+- Windows with Deno `--unstable-ffi` and `--unstable-webgpu`
+- SDL2 available to `jsr:@divy/sdl2`
+
+The repository includes a Windows-only installer script that downloads the official SDL2 runtime zip
+from `libsdl.org/release` into `vendor/sdl2/windows-x64`. The run task auto-detects that location on
+Windows, so after setup you can launch the example directly.

--- a/examples/byow_native_demo/main.ts
+++ b/examples/byow_native_demo/main.ts
@@ -1,0 +1,250 @@
+/// <reference lib="deno.unstable" />
+
+import { EventType, WindowBuilder } from 'jsr:@divy/sdl2@0.15.0';
+import { evaluateScene } from '../../packages/core/mod.ts';
+import {
+  type AssetSource,
+  configureSurfaceContext,
+  createRuntimeResidency,
+  ensureSceneMeshResidency,
+  ensureSceneTextureResidency,
+  requestGpuContext,
+} from '../../packages/gpu/mod.ts';
+import {
+  appendMaterial,
+  appendMesh,
+  appendNode,
+  appendTexture,
+  createNode,
+  createSceneIr,
+} from '../../packages/ir/mod.ts';
+import { createDenoSurfaceTarget } from '../../packages/platform/mod.ts';
+import { createMaterialRegistry, renderForwardFrame } from '../../packages/renderer/mod.ts';
+
+const width = 960;
+const height = 540;
+const textureAssetId = 'checkerboard-image';
+const textureId = 'checkerboard-texture';
+const texturedMaterialId = 'checkerboard-material';
+const accentMaterialId = 'accent-material';
+const quadMeshId = 'checkerboard-quad';
+const accentMeshId = 'accent-triangle';
+
+const scene = appendNode(
+  appendNode(
+    appendMesh(
+      appendMesh(
+        appendMaterial(
+          appendMaterial(
+            appendTexture(createSceneIr('byow-native-demo'), {
+              id: textureId,
+              assetId: textureAssetId,
+              semantic: 'baseColor',
+              colorSpace: 'srgb',
+              sampler: 'nearest-repeat',
+            }),
+            {
+              id: texturedMaterialId,
+              kind: 'unlit',
+              textures: [{
+                id: textureId,
+                assetId: textureAssetId,
+                semantic: 'baseColor',
+                colorSpace: 'srgb',
+                sampler: 'nearest-repeat',
+              }],
+              parameters: {
+                color: { x: 1, y: 1, z: 1, w: 1 },
+              },
+            },
+          ),
+          {
+            id: accentMaterialId,
+            kind: 'unlit',
+            textures: [],
+            parameters: {
+              color: { x: 0.92, y: 0.36, z: 0.18, w: 1 },
+            },
+          },
+        ),
+        {
+          id: quadMeshId,
+          materialId: texturedMaterialId,
+          attributes: [
+            {
+              semantic: 'POSITION',
+              itemSize: 3,
+              values: [
+                -0.9,
+                0.75,
+                0,
+                -0.9,
+                -0.75,
+                0,
+                0.35,
+                -0.75,
+                0,
+                0.35,
+                0.75,
+                0,
+              ],
+            },
+            {
+              semantic: 'TEXCOORD_0',
+              itemSize: 2,
+              values: [
+                0,
+                0,
+                0,
+                3,
+                3,
+                3,
+                3,
+                0,
+              ],
+            },
+          ],
+          indices: [0, 1, 2, 0, 2, 3],
+        },
+      ),
+      {
+        id: accentMeshId,
+        materialId: accentMaterialId,
+        attributes: [{
+          semantic: 'POSITION',
+          itemSize: 3,
+          values: [
+            0.15,
+            0.7,
+            0,
+            0.92,
+            0.18,
+            0,
+            0.44,
+            -0.72,
+            0,
+          ],
+        }],
+      },
+    ),
+    createNode('checkerboard-quad-node', {
+      meshId: quadMeshId,
+    }),
+  ),
+  createNode('accent-triangle-node', {
+    meshId: accentMeshId,
+  }),
+);
+
+const assetSource: AssetSource = {
+  images: new Map([[
+    textureAssetId,
+    {
+      id: textureAssetId,
+      mimeType: 'image/raw-rgba',
+      width: 4,
+      height: 4,
+      pixelFormat: 'rgba8unorm',
+      bytes: Uint8Array.from([
+        22,
+        28,
+        36,
+        255,
+        236,
+        229,
+        116,
+        255,
+        22,
+        28,
+        36,
+        255,
+        236,
+        229,
+        116,
+        255,
+        236,
+        229,
+        116,
+        255,
+        67,
+        115,
+        201,
+        255,
+        236,
+        229,
+        116,
+        255,
+        67,
+        115,
+        201,
+        255,
+        22,
+        28,
+        36,
+        255,
+        236,
+        229,
+        116,
+        255,
+        22,
+        28,
+        36,
+        255,
+        236,
+        229,
+        116,
+        255,
+        236,
+        229,
+        116,
+        255,
+        67,
+        115,
+        201,
+        255,
+        236,
+        229,
+        116,
+        255,
+        67,
+        115,
+        201,
+        255,
+      ]),
+    },
+  ]]),
+  volumes: new Map(),
+};
+
+const window = new WindowBuilder('rieul3d byow native demo', width, height).build();
+const target = createDenoSurfaceTarget(width, height);
+const gpuContext = await requestGpuContext({ target });
+const windowSurface = window.windowSurface(width, height);
+const canvasContext = windowSurface.getContext('webgpu');
+
+const surfaceBinding = configureSurfaceContext(
+  gpuContext,
+  canvasContext as unknown as GPUCanvasContext,
+);
+const residency = createRuntimeResidency();
+const materialRegistry = createMaterialRegistry();
+const evaluatedScene = evaluateScene(scene, { timeMs: 0 });
+
+ensureSceneMeshResidency(gpuContext, residency, scene, evaluatedScene);
+ensureSceneTextureResidency(gpuContext, residency, scene, assetSource);
+
+const drawFrame = () => {
+  renderForwardFrame(gpuContext, surfaceBinding, residency, evaluatedScene, materialRegistry);
+  windowSurface.present();
+};
+
+for await (const event of window.events()) {
+  switch (event.type) {
+    case EventType.Draw:
+      drawFrame();
+      break;
+    case EventType.Quit:
+      Deno.exit(0);
+      break;
+  }
+}

--- a/packages/platform/src/targets.ts
+++ b/packages/platform/src/targets.ts
@@ -1,6 +1,6 @@
 import type { OffscreenTarget, SurfaceTarget } from '@rieul3d/gpu';
 
-export const createBrowserSurfaceTarget = (
+export const createSurfaceTarget = (
   width: number,
   height: number,
   format: GPUTextureFormat = 'bgra8unorm',
@@ -10,6 +10,9 @@ export const createBrowserSurfaceTarget = (
   height,
   format,
 });
+
+export const createBrowserSurfaceTarget = createSurfaceTarget;
+export const createDenoSurfaceTarget = createSurfaceTarget;
 
 export const createHeadlessTarget = (
   width: number,

--- a/scripts/run_byow_native_demo.ts
+++ b/scripts/run_byow_native_demo.ts
@@ -1,0 +1,17 @@
+import { exists } from '@std/fs';
+import { dirname, fromFileUrl, join } from '@std/path';
+
+const repoRoot = join(dirname(fromFileUrl(import.meta.url)), '..');
+const windowsSdl2Path = join(repoRoot, 'vendor', 'sdl2', 'windows-x64');
+
+if (Deno.build.os === 'windows' && !Deno.env.get('DENO_SDL2_PATH')) {
+  if (!(await exists(windowsSdl2Path))) {
+    throw new Error(
+      'SDL2 runtime is not installed. Run `deno task setup:sdl2:windows` first.',
+    );
+  }
+
+  Deno.env.set('DENO_SDL2_PATH', windowsSdl2Path);
+}
+
+await import('../examples/byow_native_demo/main.ts');

--- a/tests/context_targets_test.ts
+++ b/tests/context_targets_test.ts
@@ -7,7 +7,11 @@ import {
   getRenderTargetByteSize,
   getRenderTargetSize,
 } from '@rieul3d/gpu';
-import { createBrowserSurfaceTarget, createHeadlessTarget } from '@rieul3d/platform';
+import {
+  createBrowserSurfaceTarget,
+  createDenoSurfaceTarget,
+  createHeadlessTarget,
+} from '@rieul3d/platform';
 
 type MockTexture = Readonly<{
   id: number;
@@ -136,6 +140,12 @@ Deno.test('surface/offscreen helpers reject mismatched target kinds and expose t
     )
   );
 
+  assertEquals(createDenoSurfaceTarget(12, 6), {
+    kind: 'surface',
+    width: 12,
+    height: 6,
+    format: 'bgra8unorm',
+  });
   assertEquals(getRenderTargetSize(createHeadlessTarget(8, 4)), { width: 8, height: 4 });
   assertEquals(getRenderTargetByteSize(createHeadlessTarget(8, 4)), 128);
 });


### PR DESCRIPTION
## Summary
- replace the startup BYOW triangle workflow with a runtime-backed native demo that renders an indexed textured quad plus a second mesh on an SDL2 surface
- add an explicit Deno/native surface target helper and cover it in the context target tests
- refresh the root/docs/examples documentation so the native BYOW workflow and expected output are discoverable

## Verification
- deno task example:byow:check
- deno test --unstable-raw-imports tests/context_targets_test.ts
- deno task docs:check
- deno task check

## Follow-up
- opened #41 for mesh transform application in the forward renderer, which blocked meaningful transform-driven animation in this demo path

Closes #29