### PR TITLE
Generalize material bindings for texture-backed programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Implemented today:
 - mesh, texture, and first volume residency upload paths
 - forward rendering, first SDF raymarch execution, and headless snapshot readback
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
-  sampling, material parameter uploads, and custom WGSL registration
+  sampling, material parameter uploads, custom WGSL registration, and declared material texture
+  bindings
 - glTF JSON, GLB, data-URI buffers, and caller-provided external glTF resource ingestion
 - browser canvas examples, Windows BYOW native textured demo, headless PNG snapshot workflow, and
   PNG snapshot encoding

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -56,11 +56,15 @@ The initial renderer uses a lightweight pass graph:
 
 - Built-in forward mesh shaders reserve `@group(0) @binding(0)` for a `mat4x4<f32>` mesh transform
   uniform derived from the evaluated node world matrix.
+- Material programs can declare `materialBindings` entries for uniform buffers, texture views, and
+  samplers that are assembled into a single material bind group.
 - Built-in unlit material uniforms live at `@group(1) @binding(0)`.
 - Built-in textured unlit shading also binds base-color texture/view pairs at
   `@group(1) @binding(1)` and `@group(1) @binding(2)`.
 - Custom WGSL programs that want the same evaluated mesh transform upload should register with
   `usesTransformBindings: true` and match the same `@group(0)` transform contract.
+- Custom WGSL programs that need sampled textures should declare matching texture/sampler bindings
+  plus the texture semantic they expect from `Material.textures`.
 
 ## Headless PNG Workflow
 
@@ -73,7 +77,6 @@ The initial renderer uses a lightweight pass graph:
 ## Known Gaps
 
 - Deferred rendering is still at the planning-contract stage.
-- Generalized texture-backed material binding for arbitrary custom programs is not implemented yet.
 - Volume rendering passes are not encoded yet; only their residency/extraction scaffolding exists.
 - SDF execution currently supports sphere primitives only; broader graph/operator coverage is still
   pending.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -99,7 +99,25 @@ export type MaterialProgram = Readonly<{
   vertexAttributes: readonly MaterialVertexAttribute[];
   usesMaterialBindings?: boolean;
   usesTransformBindings?: boolean;
+  materialBindings?: readonly MaterialBindingDescriptor[];
 }>;
+
+export type MaterialBindingDescriptor = Readonly<
+  | {
+    kind: 'uniform';
+    binding: number;
+  }
+  | {
+    kind: 'texture';
+    binding: number;
+    textureSemantic: string;
+  }
+  | {
+    kind: 'sampler';
+    binding: number;
+    textureSemantic: string;
+  }
+>;
 
 export type MaterialRegistry = Readonly<{
   programs: Map<string, MaterialProgram>;
@@ -155,6 +173,10 @@ const builtInUnlitProgram: MaterialProgram = {
   fragmentEntryPoint: 'fsMain',
   usesMaterialBindings: true,
   usesTransformBindings: true,
+  materialBindings: [{
+    kind: 'uniform',
+    binding: 0,
+  }],
   vertexAttributes: [{
     semantic: 'POSITION',
     shaderLocation: 0,
@@ -172,6 +194,22 @@ const builtInTexturedUnlitProgram: MaterialProgram = {
   fragmentEntryPoint: 'fsMain',
   usesMaterialBindings: true,
   usesTransformBindings: true,
+  materialBindings: [
+    {
+      kind: 'uniform',
+      binding: 0,
+    },
+    {
+      kind: 'texture',
+      binding: 1,
+      textureSemantic: 'baseColor',
+    },
+    {
+      kind: 'sampler',
+      binding: 2,
+      textureSemantic: 'baseColor',
+    },
+  ],
   vertexAttributes: [
     {
       semantic: 'POSITION',
@@ -261,6 +299,77 @@ const getBaseColorTextureResidency = (
 ): TextureResidency | undefined => {
   const textureRef = material.textures.find((texture) => texture.semantic === 'baseColor');
   return textureRef ? residency.textures.get(textureRef.id) : undefined;
+};
+
+const getMaterialTextureResidency = (
+  residency: RuntimeResidency,
+  material: Material,
+  textureSemantic: string,
+): TextureResidency | undefined => {
+  const textureRef = material.textures.find((texture) => texture.semantic === textureSemantic);
+  return textureRef ? residency.textures.get(textureRef.id) : undefined;
+};
+
+const defaultMaterialBindings = [{
+  kind: 'uniform',
+  binding: 0,
+}] as const satisfies readonly MaterialBindingDescriptor[];
+
+const getMaterialBindingDescriptors = (
+  program: MaterialProgram,
+): readonly MaterialBindingDescriptor[] =>
+  program.materialBindings ?? (program.usesMaterialBindings ? defaultMaterialBindings : []);
+
+const resolveMaterialBindingResource = (
+  context: GpuRenderExecutionContext,
+  residency: RuntimeResidency,
+  material: Material,
+  descriptor: MaterialBindingDescriptor,
+  materialResidency: { current?: ReturnType<typeof ensureMaterialResidency> },
+): GPUBindGroupEntry => {
+  switch (descriptor.kind) {
+    case 'uniform': {
+      materialResidency.current ??= ensureMaterialResidency(context, residency, material);
+      return {
+        binding: descriptor.binding,
+        resource: {
+          buffer: materialResidency.current.uniformBuffer,
+        },
+      };
+    }
+    case 'texture': {
+      const textureResidency = getMaterialTextureResidency(
+        residency,
+        material,
+        descriptor.textureSemantic,
+      );
+      if (!textureResidency) {
+        throw new Error(
+          `material "${material.id}" is missing residency for "${descriptor.textureSemantic}" texture binding`,
+        );
+      }
+      return {
+        binding: descriptor.binding,
+        resource: textureResidency.view,
+      };
+    }
+    case 'sampler': {
+      const textureResidency = getMaterialTextureResidency(
+        residency,
+        material,
+        descriptor.textureSemantic,
+      );
+      if (!textureResidency) {
+        throw new Error(
+          `material "${material.id}" is missing residency for "${descriptor.textureSemantic}" sampler binding`,
+        );
+      }
+      return {
+        binding: descriptor.binding,
+        resource: textureResidency.sampler,
+      };
+    }
+  }
 };
 
 export const createForwardRenderer = (label = 'forward'): Renderer => ({
@@ -651,8 +760,6 @@ export const renderForwardFrame = (
         preferTexturedUnlit: true,
       })
       : resolvedProgram;
-    const supportsTexturedUnlit = program.id === builtInTexturedUnlitProgramId &&
-      Boolean(baseColorTexture);
     const pipeline = ensureMaterialPipeline(context, residency, program, binding.target.format);
 
     let isDrawable = true;
@@ -698,31 +805,23 @@ export const renderForwardFrame = (
       pass.setBindGroup(0, transformBindGroup);
     }
 
-    if (program.usesMaterialBindings) {
-      const materialResidency = ensureMaterialResidency(context, residency, material);
+    const materialBindings = getMaterialBindingDescriptors(program);
+    if (materialBindings.length > 0) {
       const materialBindGroupIndex = program.usesTransformBindings ? 1 : 0;
+      const materialResidency = {
+        current: undefined as ReturnType<typeof ensureMaterialResidency> | undefined,
+      };
       const bindGroup = context.device.createBindGroup({
         layout: pipeline.getBindGroupLayout(materialBindGroupIndex),
-        entries: [
-          {
-            binding: 0,
-            resource: {
-              buffer: materialResidency.uniformBuffer,
-            },
-          },
-          ...(supportsTexturedUnlit && baseColorTexture
-            ? [
-              {
-                binding: 1,
-                resource: baseColorTexture.view,
-              },
-              {
-                binding: 2,
-                resource: baseColorTexture.sampler,
-              },
-            ]
-            : []),
-        ],
+        entries: materialBindings.map((descriptor) =>
+          resolveMaterialBindingResource(
+            context,
+            residency,
+            material,
+            descriptor,
+            materialResidency,
+          )
+        ),
       });
       pass.setBindGroup(materialBindGroupIndex, bindGroup);
     }

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -311,6 +311,7 @@ fn fsMain() -> @location(0) vec4<f32> {
 `,
     vertexEntryPoint: 'vsMain',
     fragmentEntryPoint: 'fsMain',
+    usesTransformBindings: true,
     vertexAttributes: [{
       semantic: 'POSITION',
       shaderLocation: 0,
@@ -386,6 +387,7 @@ fn fsMain() -> @location(0) vec4<f32> {
 `,
     vertexEntryPoint: 'vsMain',
     fragmentEntryPoint: 'fsMain',
+    usesTransformBindings: true,
     vertexAttributes: [{
       semantic: 'POSITION',
       shaderLocation: 0,
@@ -447,7 +449,8 @@ fn fsMain() -> @location(0) vec4<f32> {
 
   assertEquals(mocks.pipelines.length, 1);
   assertEquals(mocks.shaders.length, 1);
-  assertEquals(mocks.bindGroupEntries.length, 0);
+  assertEquals(mocks.bindGroupEntries.length, 1);
+  assertEquals(mocks.bindGroupEntries[0].map((entry) => entry.binding), [0]);
 });
 
 Deno.test('renderForwardFrame binds base-color textures for textured built-in unlit materials', () => {
@@ -585,6 +588,134 @@ Deno.test('renderForwardFrame does not append texture bindings for shader-select
   assertEquals(mocks.bindGroupEntries.length, 2);
   assertEquals(mocks.bindGroupEntries[0].map((entry) => entry.binding), [0]);
   assertEquals(mocks.bindGroupEntries[1].map((entry) => entry.binding), [0]);
+});
+
+Deno.test('renderForwardFrame assembles declared texture and sampler bindings for custom programs', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  const registry = createMaterialRegistry();
+  const customProgram = {
+    id: 'shader:textured-flat-red',
+    label: 'Textured Flat Red',
+    wgsl: `
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+struct MeshTransform {
+  world: mat4x4<f32>,
+};
+
+struct MaterialUniforms {
+  color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> meshTransform: MeshTransform;
+@group(1) @binding(0) var<uniform> material: MaterialUniforms;
+@group(1) @binding(1) var baseColorTexture: texture_2d<f32>;
+@group(1) @binding(2) var baseColorSampler: sampler;
+
+@vertex
+fn vsMain(@location(0) position: vec3<f32>, @location(1) uv: vec2<f32>) -> VsOut {
+  var out: VsOut;
+  out.position = meshTransform.world * vec4<f32>(position, 1.0);
+  out.uv = uv;
+  return out;
+}
+
+@fragment
+fn fsMain(input: VsOut) -> @location(0) vec4<f32> {
+  return textureSample(baseColorTexture, baseColorSampler, input.uv) * material.color;
+}
+`,
+    vertexEntryPoint: 'vsMain',
+    fragmentEntryPoint: 'fsMain',
+    usesTransformBindings: true,
+    materialBindings: [
+      { kind: 'uniform' as const, binding: 0 },
+      { kind: 'texture' as const, binding: 1, textureSemantic: 'baseColor' },
+      { kind: 'sampler' as const, binding: 2, textureSemantic: 'baseColor' },
+    ],
+    vertexAttributes: [
+      {
+        semantic: 'POSITION',
+        shaderLocation: 0,
+        format: 'float32x3' as GPUVertexFormat,
+        offset: 0,
+        arrayStride: 12,
+      },
+      {
+        semantic: 'TEXCOORD_0',
+        shaderLocation: 1,
+        format: 'float32x2' as GPUVertexFormat,
+        offset: 0,
+        arrayStride: 8,
+      },
+    ],
+  };
+  registerWgslMaterial(registry, customProgram);
+
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-custom-textured',
+    kind: 'custom',
+    shaderId: 'shader:textured-flat-red',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {
+      color: { x: 1, y: 0.5, z: 0.5, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-custom-textured',
+    materialId: 'material-custom-textured',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('node-custom-textured', { meshId: 'mesh-custom-textured' }));
+
+  runtimeResidency.geometry.set('mesh-custom-textured', {
+    meshId: 'mesh-custom-textured',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      TEXCOORD_0: { id: 1 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  runtimeResidency.textures.set('texture-0', {
+    textureId: 'texture-0',
+    texture: {} as GPUTexture,
+    view: { textureId: 0 } as unknown as GPUTextureView,
+    sampler: { id: 0 } as unknown as GPUSampler,
+    width: 2,
+    height: 2,
+    format: 'rgba8unorm',
+  });
+
+  const result = renderForwardFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    createOffscreenContext({
+      device: mocks.device as unknown as GPUDevice,
+      target: createHeadlessTarget(64, 64),
+    }),
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+    registry,
+  );
+
+  assertEquals(result.drawCount, 1);
+  assertEquals(mocks.bindGroupEntries.length, 2);
+  assertEquals(mocks.bindGroupEntries[0].map((entry) => entry.binding), [0]);
+  assertEquals(mocks.bindGroupEntries[1].map((entry) => entry.binding), [0, 1, 2]);
 });
 
 Deno.test('renderForwardFrame uploads evaluated mesh transforms for built-in unlit draws', () => {


### PR DESCRIPTION
## Summary
- let material programs declare uniform, texture, and sampler bindings through a shared material binding contract
- reuse the same forward-render bind group assembly path for built-in textured unlit and custom WGSL programs
- add custom textured shader coverage and update rendering docs to reflect the new contract

## Testing
- deno task check

Closes #26