### PR TITLE
Strengthen renderer capability diagnostics

### DIFF
--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -64,7 +64,12 @@ Each issue should include:
 
 - the evaluated node ID
 - the failing feature category
+- a machine-friendly requirement key for the exact unsupported shape, binding, or capability
 - a human-readable message that names the renderer and unsupported requirement
+
+Current requirement keys include renderer execution gates such as `mesh-execution`, shape-specific
+keys such as `sdf-op:box`, and binding-specific keys such as `shader:shader:missing`,
+`texture-semantic:normal`, or `vertex-attribute:TEXCOORD_0`.
 
 Fatal render entry points should throw with the aggregated issue list when any incompatibility is
 present. Non-fatal tooling may inspect the issue list directly for UI, tests, or diagnostics.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -144,7 +144,8 @@ export type SdfPassItem = Readonly<{
 
 export type RendererCapabilityIssue = Readonly<{
   nodeId: string;
-  feature: 'mesh' | 'sdf' | 'volume' | 'material-kind' | 'custom-shader';
+  feature: 'mesh' | 'sdf' | 'volume' | 'material-kind' | 'custom-shader' | 'material-binding';
+  requirement: string;
   message: string;
 }>;
 
@@ -434,61 +435,130 @@ export const planFrame = (
 export const collectRendererCapabilityIssues = (
   renderer: Renderer,
   evaluatedScene: EvaluatedScene,
+  materialRegistry = createMaterialRegistry(),
 ): readonly RendererCapabilityIssue[] =>
   evaluatedScene.nodes.flatMap((node) => {
     const issues: RendererCapabilityIssue[] = [];
+    const hasTexcoord0 = Boolean(
+      node.mesh?.attributes.some((attribute) => attribute.semantic === 'TEXCOORD_0'),
+    );
+    const material = node.material;
+    const materialTextures = material?.textures ?? [];
+    const issueKeys = new Set<string>();
+    const pushIssue = (
+      feature: RendererCapabilityIssue['feature'],
+      requirement: string,
+      message: string,
+    ) => {
+      const key = `${feature}:${requirement}`;
+      if (issueKeys.has(key)) {
+        return;
+      }
 
-    if (node.mesh && renderer.capabilities.mesh !== 'supported') {
+      issueKeys.add(key);
       issues.push({
         nodeId: node.node.id,
-        feature: 'mesh',
-        message: `renderer "${renderer.label}" does not support mesh execution`,
+        feature,
+        requirement,
+        message,
       });
+    };
+
+    if (node.mesh && renderer.capabilities.mesh !== 'supported') {
+      pushIssue(
+        'mesh',
+        'mesh-execution',
+        `renderer "${renderer.label}" does not support mesh execution`,
+      );
     }
 
     if (node.sdf) {
       if (renderer.capabilities.sdf !== 'supported') {
-        issues.push({
-          nodeId: node.node.id,
-          feature: 'sdf',
-          message: `renderer "${renderer.label}" does not support sdf execution`,
-        });
+        pushIssue(
+          'sdf',
+          'sdf-execution',
+          `renderer "${renderer.label}" does not support sdf execution`,
+        );
       } else if (node.sdf.op !== 'sphere') {
-        issues.push({
-          nodeId: node.node.id,
-          feature: 'sdf',
-          message: `renderer "${renderer.label}" only supports sphere sdf primitives right now`,
-        });
+        pushIssue(
+          'sdf',
+          `sdf-op:${node.sdf.op}`,
+          `renderer "${renderer.label}" only supports sphere sdf primitives right now; node "${node.node.id}" requested "${node.sdf.op}"`,
+        );
       }
     }
 
     if (node.volume && renderer.capabilities.volume !== 'supported') {
-      issues.push({
-        nodeId: node.node.id,
-        feature: 'volume',
-        message: `renderer "${renderer.label}" does not support volume execution`,
-      });
+      pushIssue(
+        'volume',
+        'volume-execution',
+        `renderer "${renderer.label}" does not support volume execution`,
+      );
     }
 
     if (
-      node.material &&
-      !node.material.shaderId &&
-      !renderer.capabilities.builtInMaterialKinds.includes(node.material.kind)
+      material &&
+      !material.shaderId &&
+      !renderer.capabilities.builtInMaterialKinds.includes(material.kind)
     ) {
-      issues.push({
-        nodeId: node.node.id,
-        feature: 'material-kind',
-        message:
-          `renderer "${renderer.label}" does not support built-in material kind "${node.material.kind}"`,
-      });
+      pushIssue(
+        'material-kind',
+        `material-kind:${material.kind}`,
+        `renderer "${renderer.label}" does not support built-in material kind "${material.kind}"`,
+      );
     }
 
-    if (node.material?.shaderId && renderer.capabilities.customShaders !== 'supported') {
-      issues.push({
-        nodeId: node.node.id,
-        feature: 'custom-shader',
-        message: `renderer "${renderer.label}" does not support custom shader materials`,
-      });
+    if (material?.shaderId) {
+      if (renderer.capabilities.customShaders !== 'supported') {
+        pushIssue(
+          'custom-shader',
+          `shader:${material.shaderId}`,
+          `renderer "${renderer.label}" does not support custom shader materials`,
+        );
+      } else {
+        const program = materialRegistry.programs.get(material.shaderId);
+        if (!program) {
+          pushIssue(
+            'material-binding',
+            `shader:${material.shaderId}`,
+            `renderer "${renderer.label}" cannot resolve custom shader "${material.shaderId}" for material "${material.id}"`,
+          );
+        } else {
+          for (const descriptor of getMaterialBindingDescriptors(program)) {
+            if (descriptor.kind === 'uniform') {
+              continue;
+            }
+
+            const semantic = descriptor.textureSemantic;
+            if (!materialTextures.some((texture) => texture.semantic === semantic)) {
+              pushIssue(
+                'material-binding',
+                `texture-semantic:${semantic}`,
+                `renderer "${renderer.label}" cannot satisfy "${semantic}" ${descriptor.kind} binding for material "${material.id}"`,
+              );
+            }
+
+            if (node.mesh && !hasTexcoord0) {
+              pushIssue(
+                'material-binding',
+                'vertex-attribute:TEXCOORD_0',
+                `renderer "${renderer.label}" cannot sample material "${material.id}" on node "${node.node.id}" because mesh "${node.mesh.id}" is missing TEXCOORD_0`,
+              );
+            }
+          }
+        }
+      }
+    } else if (
+      material?.kind === 'unlit' &&
+      materialTextures.some((texture) => texture.semantic === 'baseColor') &&
+      node.mesh &&
+      !hasTexcoord0
+    ) {
+      pushIssue(
+        'material-binding',
+        'vertex-attribute:TEXCOORD_0',
+        `renderer "${renderer.label}" cannot sample baseColor textures on node "${node.node.id}" because mesh "${node.mesh.id}" is missing TEXCOORD_0`,
+      );
     }
 
     return issues;
@@ -497,13 +567,19 @@ export const collectRendererCapabilityIssues = (
 export const assertRendererSceneCapabilities = (
   renderer: Renderer,
   evaluatedScene: EvaluatedScene,
+  materialRegistry = createMaterialRegistry(),
 ): void => {
-  const issues = collectRendererCapabilityIssues(renderer, evaluatedScene);
+  const issues = collectRendererCapabilityIssues(renderer, evaluatedScene, materialRegistry);
   if (issues.length === 0) {
     return;
   }
 
-  throw new Error(issues.map((issue) => `[${issue.nodeId}] ${issue.message}`).join('\n'));
+  throw new Error(
+    issues.map((issue) =>
+      `[${issue.nodeId}] (${issue.feature}:${issue.requirement}) ${issue.message}`
+    )
+      .join('\n'),
+  );
 };
 
 export const extractVolumePassItems = (
@@ -931,7 +1007,7 @@ export const renderForwardFrame = (
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
 ): ForwardRenderResult => {
-  assertRendererSceneCapabilities(createForwardRenderer(), evaluatedScene);
+  assertRendererSceneCapabilities(createForwardRenderer(), evaluatedScene, materialRegistry);
   const view = acquireColorAttachmentView(binding);
   const encoder = context.device.createCommandEncoder({
     label: 'forward-frame',

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -7,10 +7,96 @@ import {
   collectRendererCapabilityIssues,
   createDeferredRenderer,
   createForwardRenderer,
+  createMaterialRegistry,
   extractSdfPassItems,
   extractVolumePassItems,
+  type MaterialProgram,
   planFrame,
+  registerWgslMaterial,
 } from '@rieul3d/renderer';
+
+const createFlatRedProgram = (): MaterialProgram => ({
+  id: 'shader:flat-red',
+  label: 'Flat Red',
+  wgsl: `
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+};
+
+@vertex
+fn vsMain(@location(0) position: vec3<f32>) -> VsOut {
+  var out: VsOut;
+  out.position = vec4<f32>(position, 1.0);
+  return out;
+}
+
+@fragment
+fn fsMain() -> @location(0) vec4<f32> {
+  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+`,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  vertexAttributes: [{
+    semantic: 'POSITION',
+    shaderLocation: 0,
+    format: 'float32x3',
+    offset: 0,
+    arrayStride: 12,
+  }],
+});
+
+const createTexturedCustomProgram = (): MaterialProgram => ({
+  id: 'shader:textured-custom',
+  label: 'Textured Custom',
+  wgsl: `
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+};
+
+@vertex
+fn vsMain(@location(0) position: vec3<f32>) -> VsOut {
+  var out: VsOut;
+  out.position = vec4<f32>(position, 1.0);
+  return out;
+}
+
+@group(1) @binding(0) var customTexture: texture_2d<f32>;
+@group(1) @binding(1) var customSampler: sampler;
+
+@fragment
+fn fsMain() -> @location(0) vec4<f32> {
+  return textureSample(customTexture, customSampler, vec2<f32>(0.5, 0.5));
+}
+`,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  vertexAttributes: [{
+    semantic: 'POSITION',
+    shaderLocation: 0,
+    format: 'float32x3',
+    offset: 0,
+    arrayStride: 12,
+  }],
+  usesTransformBindings: true,
+  materialBindings: [
+    {
+      kind: 'texture' as const,
+      binding: 0,
+      textureSemantic: 'baseColor',
+    },
+    {
+      kind: 'sampler' as const,
+      binding: 1,
+      textureSemantic: 'baseColor',
+    },
+    {
+      kind: 'texture' as const,
+      binding: 2,
+      textureSemantic: 'normal',
+    },
+  ],
+});
 
 Deno.test('forward renderer omits raymarch pass when scene has no sdf or volume nodes', () => {
   let scene = createSceneIr('scene');
@@ -125,6 +211,8 @@ Deno.test('extractSdfPassItems returns supported sphere sdf nodes with derived b
 });
 
 Deno.test('collectRendererCapabilityIssues accepts the current forward primitive mix', () => {
+  const materialRegistry = createMaterialRegistry();
+  registerWgslMaterial(materialRegistry, createFlatRedProgram());
   let scene = createSceneIr('scene');
   scene = appendMaterial(scene, {
     id: 'material-custom',
@@ -155,6 +243,7 @@ Deno.test('collectRendererCapabilityIssues accepts the current forward primitive
   const issues = collectRendererCapabilityIssues(
     createForwardRenderer(),
     evaluateScene(scene, { timeMs: 0 }),
+    materialRegistry,
   );
 
   assertEquals(issues, []);
@@ -173,22 +262,99 @@ Deno.test('collectRendererCapabilityIssues rejects unsupported sdf ops for execu
     evaluateScene(scene, { timeMs: 0 }),
   );
 
-  assertEquals(issues.map((issue) => issue.feature), ['sdf']);
+  assertEquals(issues, [{
+    nodeId: 'sdf-node',
+    feature: 'sdf',
+    requirement: 'sdf-op:box',
+    message:
+      'renderer "forward" only supports sphere sdf primitives right now; node "sdf-node" requested "box"',
+  }]);
 });
 
-Deno.test('assertRendererSceneCapabilities throws when renderer sees unsupported sdf ops', () => {
+Deno.test('collectRendererCapabilityIssues reports binding-specific failures in one pass', () => {
+  const materialRegistry = createMaterialRegistry();
+  registerWgslMaterial(materialRegistry, createTexturedCustomProgram());
   let scene = createSceneIr('scene');
   scene = {
     ...scene,
     sdfPrimitives: [{ id: 'sdf-0', op: 'box', parameters: {} }],
   };
+  scene = appendMaterial(scene, {
+    id: 'material-custom',
+    kind: 'custom',
+    shaderId: 'shader:textured-custom',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {},
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-custom',
+    attributes: [{ semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] }],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
   scene = appendNode(scene, createNode('sdf-node', { sdfId: 'sdf-0' }));
 
-  assertThrows(() =>
-    assertRendererSceneCapabilities(
-      createForwardRenderer(),
-      evaluateScene(scene, { timeMs: 0 }),
-    )
+  const issues = collectRendererCapabilityIssues(
+    createForwardRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+    materialRegistry,
+  );
+
+  assertEquals(issues, [
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'vertex-attribute:TEXCOORD_0',
+      message:
+        'renderer "forward" cannot sample material "material-custom" on node "mesh-node" because mesh "mesh-0" is missing TEXCOORD_0',
+    },
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'texture-semantic:normal',
+      message:
+        'renderer "forward" cannot satisfy "normal" texture binding for material "material-custom"',
+    },
+    {
+      nodeId: 'sdf-node',
+      feature: 'sdf',
+      requirement: 'sdf-op:box',
+      message:
+        'renderer "forward" only supports sphere sdf primitives right now; node "sdf-node" requested "box"',
+    },
+  ]);
+});
+
+Deno.test('assertRendererSceneCapabilities surfaces aggregated binding diagnostics cleanly', () => {
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-custom',
+    kind: 'custom',
+    shaderId: 'shader:missing',
+    textures: [],
+    parameters: {},
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-custom',
+    attributes: [{ semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] }],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+
+  assertThrows(
+    () =>
+      assertRendererSceneCapabilities(
+        createForwardRenderer(),
+        evaluateScene(scene, { timeMs: 0 }),
+      ),
+    Error,
+    '(material-binding:shader:shader:missing)',
   );
 });
 
@@ -210,5 +376,10 @@ Deno.test('planned deferred renderer features are rejected for execution preflig
     evaluateScene(scene, { timeMs: 0 }),
   );
 
-  assertEquals(issues.map((issue) => issue.feature), ['mesh']);
+  assertEquals(issues, [{
+    nodeId: 'mesh-node',
+    feature: 'mesh',
+    requirement: 'mesh-execution',
+    message: 'renderer "deferred" does not support mesh execution',
+  }]);
 });


### PR DESCRIPTION
## Summary
- enrich renderer capability issues with requirement keys for exact execution and binding failures
- preflight custom shader registration, texture semantic coverage, and TEXCOORD_0 sampling requirements
- extend renderer capability docs and tests to cover aggregated multi-issue diagnostics

## Testing
- deno test --unstable-raw-imports tests/renderer_test.ts
- deno task check
- deno task docs:check

Closes #53