### PR TITLE
Validate custom material texture residency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Implemented today:
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
 - forward rendering, first SDF raymarch execution, and headless snapshot readback
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
-  sampling, material parameter uploads, custom WGSL registration, and declared material texture
-  bindings
+  sampling, material parameter uploads, custom WGSL registration, declared material texture
+  bindings, and residency-aware custom texture binding validation
 - glTF JSON, GLB, data-URI buffers, and caller-provided external glTF resource ingestion
 - browser/Deno helpers for resolving external glTF buffers and images into the existing loader
   contract
@@ -86,6 +86,7 @@ Read in this order when onboarding:
 - `deno task example:browser:build`: bundle the browser forward-rendering example
 - `deno task example:browser:react:build`: bundle the React authoring browser example
 - `deno task example:browser:textured:build`: bundle the textured browser forward example
+- `deno task example:browser:custom-textured:build`: bundle the custom textured browser example
 - `deno task example:browser:serve`: serve the repository for local browser testing
 - `deno task example:byow:check`: type-check the Windows BYOW native demo
 - `deno task example:byow:run`: open the Windows BYOW native demo

--- a/deno.json
+++ b/deno.json
@@ -26,7 +26,7 @@
     "check": "deno fmt --check && deno task generate:ir:check && deno lint && deno test --unstable-raw-imports && deno bench --unstable-raw-imports --no-run",
     "test": "deno test --unstable-raw-imports",
     "bench": "deno bench --unstable-raw-imports",
-    "docs:check": "deno fmt --check --ignore=examples/browser_forward/dist,examples/browser_textured_forward/dist,examples/browser_react_authoring/dist docs packages tests benches examples",
+    "docs:check": "deno fmt --check --ignore=examples/browser_forward/dist,examples/browser_textured_forward/dist,examples/browser_react_authoring/dist,examples/browser_custom_textured_forward/dist docs packages tests benches examples",
     "setup:sdl2:windows": "powershell -ExecutionPolicy Bypass -File ./scripts/install_sdl2_windows.ps1",
     "example:headless:check": "deno check --unstable-webgpu --unstable-raw-imports ./scripts/render_headless_snapshot.ts",
     "example:headless:png": "deno run -A --unstable-webgpu --unstable-raw-imports ./scripts/render_headless_snapshot.ts",
@@ -35,6 +35,7 @@
     "example:browser:build": "deno bundle --platform browser --unstable-raw-imports -o ./examples/browser_forward/dist/main.js ./examples/browser_forward/main.ts",
     "example:browser:react:build": "deno bundle --platform browser --unstable-raw-imports -o ./examples/browser_react_authoring/dist/main.js ./examples/browser_react_authoring/main.ts",
     "example:browser:textured:build": "deno bundle --platform browser --unstable-raw-imports -o ./examples/browser_textured_forward/dist/main.js ./examples/browser_textured_forward/main.ts",
+    "example:browser:custom-textured:build": "deno bundle --platform browser --unstable-raw-imports -o ./examples/browser_custom_textured_forward/dist/main.js ./examples/browser_custom_textured_forward/main.ts",
     "example:browser:serve": "deno run -A jsr:@std/http@1/file-server ."
   },
   "fmt": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Use this page as the main navigation hub.
 - Understand loader and interchange direction: [`specs/interop-gltf.md`](./specs/interop-gltf.md)
 - Understand authoring boundaries: [`specs/react-authoring.md`](./specs/react-authoring.md)
 - Review accepted architecture constraints: [`adr/README.md`](./adr/README.md)
-- Run the browser and native examples, including the textured browser workflow:
+- Run the browser and native examples, including the textured and custom-material browser workflows:
   [`../examples/README.md`](../examples/README.md)
 - Review the React authoring browser example:
   [`../examples/browser_react_authoring/README.md`](../examples/browser_react_authoring/README.md)

--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -69,7 +69,7 @@ Each issue should include:
 
 Current requirement keys include renderer execution gates such as `mesh-execution`, shape-specific
 keys such as `sdf-op:box`, and binding-specific keys such as `shader:shader:missing`,
-`texture-semantic:normal`, or `vertex-attribute:TEXCOORD_0`.
+`texture-semantic:normal`, `texture-residency:baseColor:texture`, or `vertex-attribute:TEXCOORD_0`.
 
 Fatal render entry points should throw with the aggregated issue list when any incompatibility is
 present. Non-fatal tooling may inspect the issue list directly for UI, tests, or diagnostics.

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -46,7 +46,8 @@ The initial renderer uses a lightweight pass graph:
 - Custom WGSL programs can be registered and cached through the material registry.
 - Headless/offscreen rendering supports compact byte readback for snapshot testing.
 - Snapshot bytes can also be encoded into PNG for local inspection and regression workflows.
-- Browser examples cover both the minimal mesh-only path and a texture-backed unlit material path.
+- Browser examples cover the minimal mesh-only path, a texture-backed built-in unlit path, and a
+  custom WGSL path that samples texture residency through declared material bindings.
 - The native BYOW demo uses the same forward renderer/runtime residency path on an SDL2-backed
   surface target instead of a browser canvas.
 - Fixture-backed golden snapshot tests cover clear-only, mesh, SDF, volume, and recovery-rebuild
@@ -69,6 +70,8 @@ The initial renderer uses a lightweight pass graph:
   `usesTransformBindings: true` and match the same `@group(0)` transform contract.
 - Custom WGSL programs that need sampled textures should declare matching texture/sampler bindings
   plus the texture semantic they expect from `Material.textures`.
+- Capability preflight validates declared texture semantics, mesh UV requirements, and texture
+  residency before the renderer starts encoding bind groups.
 
 ## Headless PNG Workflow
 
@@ -81,6 +84,5 @@ The initial renderer uses a lightweight pass graph:
 ## Known Gaps
 
 - Deferred rendering is still at the planning-contract stage.
-- Generalized texture-backed material binding for arbitrary custom programs is not implemented yet.
 - SDF execution currently supports sphere primitives only; broader graph/operator coverage is still
   pending.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,8 @@ Runnable examples live here. Each example should document how to build, serve, o
   with scene nodes authored through `@rieul3d/react`
 - [`browser_textured_forward/README.md`](./browser_textured_forward/README.md): browser forward flow
   with uploaded texture residency and built-in unlit sampling
+- [`browser_custom_textured_forward/README.md`](./browser_custom_textured_forward/README.md):
+  browser forward flow with a custom WGSL program that declares texture and sampler bindings
 - [`headless_snapshot/README.md`](./headless_snapshot/README.md): offscreen render-to-PNG workflow
 - [`byow_triangle/README.md`](./byow_triangle/README.md): Windows BYOW surface presentation smoke
   test
@@ -22,6 +24,7 @@ Runnable examples live here. Each example should document how to build, serve, o
 - Build the browser bundle: `deno task example:browser:build`
 - Build the React authoring browser bundle: `deno task example:browser:react:build`
 - Build the textured browser bundle: `deno task example:browser:textured:build`
+- Build the custom textured browser bundle: `deno task example:browser:custom-textured:build`
 - Render a headless PNG snapshot: `deno task example:headless:png`
 - Serve the repository for local testing: `deno task example:browser:serve`
 

--- a/examples/browser_custom_textured_forward/README.md
+++ b/examples/browser_custom_textured_forward/README.md
@@ -1,0 +1,28 @@
+# Browser Custom Textured Forward Example
+
+This browser example registers a custom WGSL program that samples a `baseColor` texture through the
+general material binding path.
+
+Build the example bundle:
+
+```sh
+deno task example:browser:custom-textured:build
+```
+
+Serve the repository root as static files:
+
+```sh
+deno task example:browser:serve
+```
+
+Then open:
+
+```text
+http://localhost:8000/examples/browser_custom_textured_forward/index.html
+```
+
+Related references:
+
+- [`../../examples/README.md`](../README.md)
+- [`../../docs/specs/rendering.md`](../../docs/specs/rendering.md)
+- [`../../docs/specs/runtime-residency.md`](../../docs/specs/runtime-residency.md)

--- a/examples/browser_custom_textured_forward/index.html
+++ b/examples/browser_custom_textured_forward/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>rieul3d custom textured browser forward example</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: sans-serif;
+        background: #05070b;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background:
+          radial-gradient(circle at top, rgba(68, 176, 130, 0.22), transparent 36%),
+          radial-gradient(circle at bottom, rgba(204, 139, 62, 0.18), transparent 42%),
+          #05070b;
+      }
+
+      main {
+        display: grid;
+        gap: 12px;
+        padding: 24px;
+      }
+
+      canvas {
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        width: min(640px, calc(100vw - 48px));
+        height: auto;
+        background: #000;
+      }
+
+      p {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.72);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <canvas id="app" width="640" height="480"></canvas>
+      <p>Built from SceneIr, custom WGSL material bindings, and texture residency preflight.</p>
+    </main>
+    <script type="module" src="./dist/main.js"></script>
+  </body>
+</html>

--- a/examples/browser_custom_textured_forward/main.ts
+++ b/examples/browser_custom_textured_forward/main.ts
@@ -1,0 +1,203 @@
+/// <reference lib="dom" />
+
+import { evaluateScene } from '../../packages/core/mod.ts';
+import {
+  type AssetSource,
+  configureSurfaceContext,
+  createRuntimeResidency,
+  ensureSceneMeshResidency,
+  ensureSceneTextureResidency,
+  requestGpuContext,
+} from '../../packages/gpu/mod.ts';
+import {
+  appendMaterial,
+  appendMesh,
+  appendNode,
+  appendTexture,
+  createNode,
+  createSceneIr,
+} from '../../packages/ir/mod.ts';
+import { createBrowserSurfaceTarget } from '../../packages/platform/mod.ts';
+import {
+  createMaterialRegistry,
+  registerWgslMaterial,
+  renderForwardFrame,
+} from '../../packages/renderer/mod.ts';
+
+const canvas = document.querySelector<HTMLCanvasElement>('#app');
+if (!canvas) {
+  throw new Error('Missing #app canvas');
+}
+
+canvas.width = 640;
+canvas.height = 480;
+
+const textureAssetId = 'custom-checkerboard-image';
+const textureId = 'custom-checkerboard-texture';
+const materialId = 'custom-checkerboard-material';
+const meshId = 'custom-textured-quad';
+const shaderId = 'shader:custom-textured-unlit';
+
+const scene = appendNode(
+  appendMesh(
+    appendMaterial(
+      appendTexture(createSceneIr('browser-custom-textured-forward'), {
+        id: textureId,
+        assetId: textureAssetId,
+        semantic: 'baseColor',
+        colorSpace: 'srgb',
+        sampler: 'nearest-repeat',
+      }),
+      {
+        id: materialId,
+        kind: 'custom',
+        shaderId,
+        textures: [{
+          id: textureId,
+          assetId: textureAssetId,
+          semantic: 'baseColor',
+          colorSpace: 'srgb',
+          sampler: 'nearest-repeat',
+        }],
+        parameters: {
+          color: { x: 0.85, y: 1, z: 0.95, w: 1 },
+        },
+      },
+    ),
+    {
+      id: meshId,
+      materialId,
+      attributes: [
+        {
+          semantic: 'POSITION',
+          itemSize: 3,
+          values: [-0.7, 0.7, 0, -0.7, -0.7, 0, 0.7, -0.7, 0, 0.7, 0.7, 0],
+        },
+        {
+          semantic: 'TEXCOORD_0',
+          itemSize: 2,
+          values: [0, 0, 0, 1, 1, 1, 1, 0],
+        },
+      ],
+      indices: [0, 1, 2, 0, 2, 3],
+    },
+  ),
+  createNode('custom-textured-quad-node', {
+    meshId,
+  }),
+);
+
+const assetSource: AssetSource = {
+  images: new Map([[
+    textureAssetId,
+    {
+      id: textureAssetId,
+      mimeType: 'image/raw-rgba',
+      width: 2,
+      height: 2,
+      pixelFormat: 'rgba8unorm',
+      bytes: Uint8Array.from([
+        255,
+        96,
+        64,
+        255,
+        255,
+        230,
+        92,
+        255,
+        44,
+        112,
+        255,
+        255,
+        28,
+        28,
+        40,
+        255,
+      ]),
+    },
+  ]]),
+  volumes: new Map(),
+};
+
+const materialRegistry = registerWgslMaterial(createMaterialRegistry(), {
+  id: shaderId,
+  label: 'Custom Textured Unlit',
+  wgsl: `
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+struct MeshTransform {
+  world: mat4x4<f32>,
+};
+
+struct MaterialUniforms {
+  color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> meshTransform: MeshTransform;
+@group(1) @binding(0) var<uniform> material: MaterialUniforms;
+@group(1) @binding(1) var baseColorTexture: texture_2d<f32>;
+@group(1) @binding(2) var baseColorSampler: sampler;
+
+@vertex
+fn vsMain(@location(0) position: vec3<f32>, @location(1) uv: vec2<f32>) -> VsOut {
+  var out: VsOut;
+  out.position = meshTransform.world * vec4<f32>(position, 1.0);
+  out.uv = uv;
+  return out;
+}
+
+@fragment
+fn fsMain(input: VsOut) -> @location(0) vec4<f32> {
+  return textureSample(baseColorTexture, baseColorSampler, input.uv) * material.color;
+}
+`,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  usesMaterialBindings: true,
+  usesTransformBindings: true,
+  materialBindings: [
+    { kind: 'uniform', binding: 0 },
+    { kind: 'texture', binding: 1, textureSemantic: 'baseColor' },
+    { kind: 'sampler', binding: 2, textureSemantic: 'baseColor' },
+  ],
+  vertexAttributes: [
+    {
+      semantic: 'POSITION',
+      shaderLocation: 0,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'TEXCOORD_0',
+      shaderLocation: 1,
+      format: 'float32x2',
+      offset: 0,
+      arrayStride: 8,
+    },
+  ],
+});
+
+const target = createBrowserSurfaceTarget(canvas.width, canvas.height);
+const gpuContext = await requestGpuContext({ target });
+const canvasContext = canvas.getContext('webgpu');
+if (!canvasContext) {
+  throw new Error('Failed to acquire WebGPU canvas context');
+}
+
+const surface = configureSurfaceContext(gpuContext, canvasContext as unknown as GPUCanvasContext);
+const residency = createRuntimeResidency();
+const evaluatedScene = evaluateScene(scene, { timeMs: 0 });
+
+ensureSceneMeshResidency(gpuContext, residency, scene, evaluatedScene);
+ensureSceneTextureResidency(gpuContext, residency, scene, assetSource);
+
+const drawFrame = () => {
+  renderForwardFrame(gpuContext, surface, residency, evaluatedScene, materialRegistry);
+  requestAnimationFrame(drawFrame);
+};
+
+requestAnimationFrame(drawFrame);

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -436,6 +436,7 @@ export const collectRendererCapabilityIssues = (
   renderer: Renderer,
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
+  residency?: RuntimeResidency,
 ): readonly RendererCapabilityIssue[] =>
   evaluatedScene.nodes.flatMap((node) => {
     const issues: RendererCapabilityIssue[] = [];
@@ -530,11 +531,18 @@ export const collectRendererCapabilityIssues = (
             }
 
             const semantic = descriptor.textureSemantic;
-            if (!materialTextures.some((texture) => texture.semantic === semantic)) {
+            const textureRef = materialTextures.find((texture) => texture.semantic === semantic);
+            if (!textureRef) {
               pushIssue(
                 'material-binding',
                 `texture-semantic:${semantic}`,
                 `renderer "${renderer.label}" cannot satisfy "${semantic}" ${descriptor.kind} binding for material "${material.id}"`,
+              );
+            } else if (residency && !residency.textures.get(textureRef.id)) {
+              pushIssue(
+                'material-binding',
+                `texture-residency:${semantic}:${descriptor.kind}`,
+                `renderer "${renderer.label}" cannot satisfy "${semantic}" ${descriptor.kind} binding for material "${material.id}" because texture "${textureRef.id}" is not resident`,
               );
             }
 
@@ -559,6 +567,15 @@ export const collectRendererCapabilityIssues = (
         'vertex-attribute:TEXCOORD_0',
         `renderer "${renderer.label}" cannot sample baseColor textures on node "${node.node.id}" because mesh "${node.mesh.id}" is missing TEXCOORD_0`,
       );
+    } else if (material?.kind === 'unlit') {
+      const baseColorTexture = materialTextures.find((texture) => texture.semantic === 'baseColor');
+      if (baseColorTexture && residency && !residency.textures.get(baseColorTexture.id)) {
+        pushIssue(
+          'material-binding',
+          'texture-residency:baseColor:texture',
+          `renderer "${renderer.label}" cannot sample baseColor textures for material "${material.id}" because texture "${baseColorTexture.id}" is not resident`,
+        );
+      }
     }
 
     return issues;
@@ -568,8 +585,14 @@ export const assertRendererSceneCapabilities = (
   renderer: Renderer,
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
+  residency?: RuntimeResidency,
 ): void => {
-  const issues = collectRendererCapabilityIssues(renderer, evaluatedScene, materialRegistry);
+  const issues = collectRendererCapabilityIssues(
+    renderer,
+    evaluatedScene,
+    materialRegistry,
+    residency,
+  );
   if (issues.length === 0) {
     return;
   }
@@ -1007,7 +1030,12 @@ export const renderForwardFrame = (
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
 ): ForwardRenderResult => {
-  assertRendererSceneCapabilities(createForwardRenderer(), evaluatedScene, materialRegistry);
+  assertRendererSceneCapabilities(
+    createForwardRenderer(),
+    evaluatedScene,
+    materialRegistry,
+    residency,
+  );
   const view = acquireColorAttachmentView(binding);
   const encoder = context.device.createCommandEncoder({
     label: 'forward-frame',

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -331,6 +331,66 @@ Deno.test('collectRendererCapabilityIssues reports binding-specific failures in 
   ]);
 });
 
+Deno.test('collectRendererCapabilityIssues reports missing resident textures for custom bindings', () => {
+  const materialRegistry = createMaterialRegistry();
+  const residency = createRuntimeResidency();
+  registerWgslMaterial(materialRegistry, createTexturedCustomProgram());
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-custom',
+    kind: 'custom',
+    shaderId: 'shader:textured-custom',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {},
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-custom',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+
+  const issues = collectRendererCapabilityIssues(
+    createForwardRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+    materialRegistry,
+    residency,
+  );
+
+  assertEquals(issues, [
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'texture-residency:baseColor:texture',
+      message:
+        'renderer "forward" cannot satisfy "baseColor" texture binding for material "material-custom" because texture "texture-0" is not resident',
+    },
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'texture-residency:baseColor:sampler',
+      message:
+        'renderer "forward" cannot satisfy "baseColor" sampler binding for material "material-custom" because texture "texture-0" is not resident',
+    },
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'texture-semantic:normal',
+      message:
+        'renderer "forward" cannot satisfy "normal" texture binding for material "material-custom"',
+    },
+  ]);
+});
+
 Deno.test('assertRendererSceneCapabilities surfaces aggregated binding diagnostics cleanly', () => {
   let scene = createSceneIr('scene');
   scene = appendMaterial(scene, {
@@ -355,6 +415,45 @@ Deno.test('assertRendererSceneCapabilities surfaces aggregated binding diagnosti
       ),
     Error,
     '(material-binding:shader:shader:missing)',
+  );
+});
+
+Deno.test('assertRendererSceneCapabilities fails early for non-resident built-in texture bindings', () => {
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-textured',
+    kind: 'unlit',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {
+      color: { x: 1, y: 1, z: 1, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-textured',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+
+  assertThrows(
+    () =>
+      assertRendererSceneCapabilities(
+        createForwardRenderer(),
+        evaluateScene(scene, { timeMs: 0 }),
+        createMaterialRegistry(),
+        createRuntimeResidency(),
+      ),
+    Error,
+    '(material-binding:texture-residency:baseColor:texture)',
   );
 });
 


### PR DESCRIPTION
## Summary
- validate custom material texture/sampler bindings against declared semantics, mesh UVs, and resident textures before forward encoding
- add a browser example for a custom WGSL textured material and document the generalized binding path
- extend renderer tests to cover missing-residency diagnostics for both custom and built-in textured materials

## Testing
- deno test --unstable-raw-imports tests/renderer_test.ts tests/forward_render_test.ts
- deno task docs:check
- deno task example:browser:custom-textured:build
- deno task check

Closes #48