### PR TITLE
Expand forward SDF support beyond sphere primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Implemented today:
 - BDL-driven `SceneIr` generation with drift checks in CI
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
 - forward rendering, first SDF raymarch execution, and headless snapshot readback
+- forward SDF sphere and box raymarch execution with capability preflight alignment
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
   sampling, material parameter uploads, custom WGSL registration, declared material texture
   bindings, and residency-aware custom texture binding validation

--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -52,8 +52,8 @@ The current preflight rules are:
 - materials with `shaderId` require `capabilities.customShaders === 'supported'`
 
 Renderers may apply narrower execution limits after the top-level capability gate. For example, the
-forward renderer currently advertises SDF support but only encodes sphere SDF primitives; that
-shape-specific restriction is reported as a validation issue during the same preflight step.
+forward renderer currently advertises SDF support but only encodes sphere and box SDF primitives;
+that shape-specific restriction is reported as a validation issue during the same preflight step.
 
 ## Failure Reporting
 

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -35,7 +35,8 @@ The initial renderer uses a lightweight pass graph:
 ## Current Execution Surface
 
 - Forward rendering is the first concrete execution path and currently draws mesh residency items.
-- Forward rendering also encodes a dedicated SDF raymarch pass for supported sphere primitives.
+- Forward rendering also encodes a dedicated SDF raymarch pass for supported sphere and box
+  primitives.
 - Forward rendering also encodes a first volume raymarch pass for volume primitives with residency.
 - Built-in unlit WGSL is stored as a standalone shader file and imported as text.
 - Built-in unlit shading supports color-only meshes plus optional base-color texture sampling when
@@ -84,5 +85,5 @@ The initial renderer uses a lightweight pass graph:
 ## Known Gaps
 
 - Deferred rendering is still at the planning-contract stage.
-- SDF execution currently supports sphere primitives only; broader graph/operator coverage is still
-  pending.
+- SDF execution currently supports sphere and box primitives only; broader graph/operator coverage
+  is still pending.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -139,7 +139,19 @@ export type SdfPassItem = Readonly<{
   op: string;
   center: readonly [number, number, number];
   radius: number;
+  halfExtents: readonly [number, number, number];
   color: readonly [number, number, number, number];
+  worldToLocalRotation: readonly [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
 }>;
 
 export type RendererCapabilityIssue = Readonly<{
@@ -480,11 +492,11 @@ export const collectRendererCapabilityIssues = (
           'sdf-execution',
           `renderer "${renderer.label}" does not support sdf execution`,
         );
-      } else if (node.sdf.op !== 'sphere') {
+      } else if (!['sphere', 'box'].includes(node.sdf.op)) {
         pushIssue(
           'sdf',
           `sdf-op:${node.sdf.op}`,
-          `renderer "${renderer.label}" only supports sphere sdf primitives right now; node "${node.node.id}" requested "${node.sdf.op}"`,
+          `renderer "${renderer.label}" only supports sphere and box sdf primitives right now; node "${node.node.id}" requested "${node.sdf.op}"`,
         );
       }
     }
@@ -642,6 +654,51 @@ const getMatrixScale = (worldMatrix: readonly number[]): readonly [number, numbe
   return [scaleX, scaleY, scaleZ];
 };
 
+const normalizeVector3 = (
+  x: number,
+  y: number,
+  z: number,
+): readonly [number, number, number] => {
+  const length = Math.hypot(x, y, z);
+  if (length < 1e-8) {
+    return [0, 0, 0];
+  }
+
+  return [x / length, y / length, z / length];
+};
+
+const getWorldToLocalRotation = (
+  worldMatrix: readonly number[],
+): readonly [number, number, number, number, number, number, number, number, number] => {
+  const [axisXx, axisXy, axisXz] = normalizeVector3(
+    worldMatrix[0] ?? 0,
+    worldMatrix[1] ?? 0,
+    worldMatrix[2] ?? 0,
+  );
+  const [axisYx, axisYy, axisYz] = normalizeVector3(
+    worldMatrix[4] ?? 0,
+    worldMatrix[5] ?? 0,
+    worldMatrix[6] ?? 0,
+  );
+  const [axisZx, axisZy, axisZz] = normalizeVector3(
+    worldMatrix[8] ?? 0,
+    worldMatrix[9] ?? 0,
+    worldMatrix[10] ?? 0,
+  );
+
+  return [
+    axisXx,
+    axisXy,
+    axisXz,
+    axisYx,
+    axisYy,
+    axisYz,
+    axisZx,
+    axisZy,
+    axisZz,
+  ];
+};
+
 const invertAffineMatrix = (worldMatrix: readonly number[]): readonly number[] => {
   const m00 = worldMatrix[0] ?? 0;
   const m01 = worldMatrix[1] ?? 0;
@@ -723,13 +780,18 @@ export const extractSdfPassItems = (
   evaluatedScene: EvaluatedScene,
 ): readonly SdfPassItem[] =>
   evaluatedScene.nodes.flatMap((node) => {
-    if (!node.sdf || node.sdf.op !== 'sphere') {
+    if (!node.sdf || !['sphere', 'box'].includes(node.sdf.op)) {
       return [];
     }
 
     const [scaleX, scaleY, scaleZ] = getMatrixScale(node.worldMatrix);
     const averageScale = (scaleX + scaleY + scaleZ) / 3 || 1;
     const radius = (node.sdf.parameters.radius?.x ?? 0.5) * averageScale;
+    const halfExtents: readonly [number, number, number] = [
+      (node.sdf.parameters.size?.x ?? 0.5) * (scaleX || 1),
+      (node.sdf.parameters.size?.y ?? 0.5) * (scaleY || 1),
+      (node.sdf.parameters.size?.z ?? 0.5) * (scaleZ || 1),
+    ];
     const color = node.sdf.parameters.color ?? { x: 1, y: 0.55, z: 0.2, w: 1 };
 
     return [{
@@ -738,7 +800,9 @@ export const extractSdfPassItems = (
       op: node.sdf.op,
       center: getMatrixTranslation(node.worldMatrix),
       radius,
+      halfExtents,
       color: [color.x, color.y, color.z, color.w],
+      worldToLocalRotation: getWorldToLocalRotation(node.worldMatrix),
     }];
   });
 
@@ -889,13 +953,19 @@ export const ensureVolumeRaymarchPipeline = (
 };
 
 const createSdfUniformData = (items: readonly SdfPassItem[]): Float32Array => {
-  const uniformData = new Float32Array(8 + (maxSdfPassItems * 8));
+  const floatsPerItem = 24;
+  const uniformData = new Float32Array(8 + (maxSdfPassItems * floatsPerItem));
   uniformData[0] = Math.min(items.length, maxSdfPassItems);
 
   items.slice(0, maxSdfPassItems).forEach((item, index) => {
-    const offset = 8 + (index * 8);
-    uniformData.set([...item.center, item.radius], offset);
-    uniformData.set(item.color, offset + 4);
+    const offset = 8 + (index * floatsPerItem);
+    const opCode = item.op === 'box' ? 1 : 0;
+    uniformData.set([...item.center, opCode], offset);
+    uniformData.set([...item.halfExtents, item.radius], offset + 4);
+    uniformData.set(item.color, offset + 8);
+    uniformData.set([...item.worldToLocalRotation.slice(0, 3), 0], offset + 12);
+    uniformData.set([...item.worldToLocalRotation.slice(3, 6), 0], offset + 16);
+    uniformData.set([...item.worldToLocalRotation.slice(6, 9), 0], offset + 20);
   });
 
   return uniformData;

--- a/packages/renderer/src/shaders/built_in_sdf_raymarch.wgsl
+++ b/packages/renderer/src/shaders/built_in_sdf_raymarch.wgsl
@@ -1,6 +1,10 @@
 struct SdfItem {
-  centerRadius: vec4<f32>,
+  centerOp: vec4<f32>,
+  halfExtentsRadius: vec4<f32>,
   color: vec4<f32>,
+  worldToLocalRow0: vec4<f32>,
+  worldToLocalRow1: vec4<f32>,
+  worldToLocalRow2: vec4<f32>,
 };
 
 struct SdfUniforms {
@@ -41,7 +45,19 @@ fn sceneSdf(point: vec3<f32>) -> vec4<f32> {
 
   for (var index: u32 = 0u; index < itemCount; index = index + 1u) {
     let item = sdf.items[index];
-    let distance = length(point - item.centerRadius.xyz) - item.centerRadius.w;
+    let centeredPoint = point - item.centerOp.xyz;
+    var distance = length(centeredPoint) - item.halfExtentsRadius.w;
+
+    if (item.centerOp.w > 0.5) {
+      let localPoint = vec3<f32>(
+        dot(item.worldToLocalRow0.xyz, centeredPoint),
+        dot(item.worldToLocalRow1.xyz, centeredPoint),
+        dot(item.worldToLocalRow2.xyz, centeredPoint),
+      );
+      let q = abs(localPoint) - item.halfExtentsRadius.xyz;
+      distance = length(max(q, vec3<f32>(0.0))) + min(max(q.x, max(q.y, q.z)), 0.0);
+    }
+
     if (distance < minDistance) {
       minDistance = distance;
       color = item.color;

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -240,21 +240,41 @@ Deno.test('renderForwardFrame encodes indexed and non-indexed draws from mesh re
   );
 });
 
-Deno.test('renderForwardFrame encodes a dedicated sdf raymarch pass for supported sphere nodes', () => {
+Deno.test('renderForwardFrame encodes a dedicated sdf raymarch pass for supported sphere and box nodes', () => {
   const mocks = createRenderMocks();
   const runtimeResidency = createRuntimeResidency();
   let scene = createSceneIr('scene');
   scene = {
     ...scene,
-    sdfPrimitives: [{
-      id: 'sdf-sphere',
-      op: 'sphere',
-      parameters: {
-        radius: { x: 0.75, y: 0, z: 0, w: 0 },
+    sdfPrimitives: [
+      {
+        id: 'sdf-sphere',
+        op: 'sphere',
+        parameters: {
+          radius: { x: 0.75, y: 0, z: 0, w: 0 },
+        },
       },
-    }],
+      {
+        id: 'sdf-box',
+        op: 'box',
+        parameters: {
+          size: { x: 0.3, y: 0.4, z: 0.5, w: 0 },
+        },
+      },
+    ],
   };
   scene = appendNode(scene, createNode('sdf-node', { sdfId: 'sdf-sphere' }));
+  scene = appendNode(
+    scene,
+    createNode('box-node', {
+      sdfId: 'sdf-box',
+      transform: {
+        translation: { x: 0.5, y: 0.25, z: -0.5 },
+        rotation: { x: 0, y: 0, z: 0.70710678, w: 0.70710678 },
+        scale: { x: 2, y: 1.5, z: 1 },
+      },
+    }),
+  );
 
   const binding = createOffscreenContext({
     device: mocks.device as unknown as GPUDevice,

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from 'jsr:@std/assert@^1.0.14';
+import { assertAlmostEquals, assertEquals, assertThrows } from 'jsr:@std/assert@^1.0.14';
 import { evaluateScene } from '@rieul3d/core';
 import { createRuntimeResidency } from '@rieul3d/gpu';
 import { appendMaterial, appendMesh, appendNode, createNode, createSceneIr } from '@rieul3d/ir';
@@ -165,7 +165,7 @@ Deno.test('extractVolumePassItems returns only evaluated volumes with residency'
   assertEquals(items[0].volumeId, 'volume-0');
 });
 
-Deno.test('extractSdfPassItems returns supported sphere sdf nodes with derived bounds', () => {
+Deno.test('extractSdfPassItems returns supported sphere and box sdf nodes with derived bounds', () => {
   let scene = createSceneIr('scene');
   scene = {
     ...scene,
@@ -181,7 +181,10 @@ Deno.test('extractSdfPassItems returns supported sphere sdf nodes with derived b
       {
         id: 'sdf-box',
         op: 'box',
-        parameters: {},
+        parameters: {
+          size: { x: 1, y: 2, z: 3, w: 0 },
+          color: { x: 1, y: 0.2, z: 0.1, w: 1 },
+        },
       },
     ],
   };
@@ -196,18 +199,48 @@ Deno.test('extractSdfPassItems returns supported sphere sdf nodes with derived b
       },
     }),
   );
-  scene = appendNode(scene, createNode('box-node', { sdfId: 'sdf-box' }));
+  scene = appendNode(
+    scene,
+    createNode('box-node', {
+      sdfId: 'sdf-box',
+      transform: {
+        translation: { x: -2, y: 0, z: 1 },
+        rotation: { x: 0, y: 0, z: 0.70710678, w: 0.70710678 },
+        scale: { x: 4, y: 5, z: 6 },
+      },
+    }),
+  );
 
   const items = extractSdfPassItems(evaluateScene(scene, { timeMs: 0 }));
 
-  assertEquals(items, [{
+  assertEquals(items[0], {
     nodeId: 'sphere-node',
     sdfId: 'sdf-sphere',
     op: 'sphere',
     center: [1, 2, 3],
     radius: 4,
+    halfExtents: [1, 1, 1],
     color: [0.4, 0.8, 1, 1],
-  }]);
+    worldToLocalRotation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+  });
+  assertEquals(items[1].nodeId, 'box-node');
+  assertEquals(items[1].sdfId, 'sdf-box');
+  assertEquals(items[1].op, 'box');
+  assertEquals(items[1].center, [-2, 0, 1]);
+  assertEquals(items[1].color, [1, 0.2, 0.1, 1]);
+  assertAlmostEquals(items[1].radius, 2.5, 1e-6);
+  assertAlmostEquals(items[1].halfExtents[0], 4, 1e-6);
+  assertAlmostEquals(items[1].halfExtents[1], 10, 1e-6);
+  assertAlmostEquals(items[1].halfExtents[2], 18, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[0], 0, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[1], 1, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[2], 0, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[3], -1, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[4], 0, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[5], 0, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[6], 0, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[7], 0, 1e-6);
+  assertAlmostEquals(items[1].worldToLocalRotation[8], 1, 1e-6);
 });
 
 Deno.test('collectRendererCapabilityIssues accepts the current forward primitive mix', () => {
@@ -249,7 +282,7 @@ Deno.test('collectRendererCapabilityIssues accepts the current forward primitive
   assertEquals(issues, []);
 });
 
-Deno.test('collectRendererCapabilityIssues rejects unsupported sdf ops for execution', () => {
+Deno.test('collectRendererCapabilityIssues accepts supported box sdf ops for execution', () => {
   let scene = createSceneIr('scene');
   scene = {
     ...scene,
@@ -262,13 +295,7 @@ Deno.test('collectRendererCapabilityIssues rejects unsupported sdf ops for execu
     evaluateScene(scene, { timeMs: 0 }),
   );
 
-  assertEquals(issues, [{
-    nodeId: 'sdf-node',
-    feature: 'sdf',
-    requirement: 'sdf-op:box',
-    message:
-      'renderer "forward" only supports sphere sdf primitives right now; node "sdf-node" requested "box"',
-  }]);
+  assertEquals(issues, []);
 });
 
 Deno.test('collectRendererCapabilityIssues reports binding-specific failures in one pass', () => {
@@ -277,7 +304,7 @@ Deno.test('collectRendererCapabilityIssues reports binding-specific failures in 
   let scene = createSceneIr('scene');
   scene = {
     ...scene,
-    sdfPrimitives: [{ id: 'sdf-0', op: 'box', parameters: {} }],
+    sdfPrimitives: [{ id: 'sdf-0', op: 'torus', parameters: {} }],
   };
   scene = appendMaterial(scene, {
     id: 'material-custom',
@@ -324,9 +351,9 @@ Deno.test('collectRendererCapabilityIssues reports binding-specific failures in 
     {
       nodeId: 'sdf-node',
       feature: 'sdf',
-      requirement: 'sdf-op:box',
+      requirement: 'sdf-op:torus',
       message:
-        'renderer "forward" only supports sphere sdf primitives right now; node "sdf-node" requested "box"',
+        'renderer "forward" only supports sphere and box sdf primitives right now; node "sdf-node" requested "torus"',
     },
   ]);
 });


### PR DESCRIPTION
## Summary
- extend forward SDF extraction, validation, and shader uniforms to execute both sphere and box primitives
- add renderer and forward render coverage for box SDF nodes, including rotated box transforms
- refresh README/spec docs and track box SDF golden snapshot follow-up in #61

## Testing
- deno test --unstable-raw-imports tests/renderer_test.ts tests/forward_render_test.ts
- deno task docs:check
- deno task check

Closes #49