### PR TITLE
Add deferred textured unlit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Implemented today:
 
 - BDL-driven `SceneIr` generation with drift checks in CI
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
-- forward rendering, minimal deferred mesh/unlit execution, first SDF raymarch execution, and
-  headless snapshot readback
+- forward rendering, minimal deferred mesh/unlit execution with optional baseColor texture sampling,
+  first SDF raymarch execution, and headless snapshot readback
 - forward SDF sphere and box raymarch execution with capability preflight alignment
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
   sampling, material parameter uploads, custom WGSL registration, declared material texture
@@ -50,7 +50,7 @@ Implemented today:
 - device-loss observation and residency rebuild helpers plus end-to-end offscreen recovery coverage
 - benchmark coverage for residency, material binding, and renderer capability preflight paths
 - renderer capability preflight for primitive and material compatibility, including deferred-path
-  NORMAL/baseColor texture gating
+  NORMAL, TEXCOORD_0, and baseColor residency gating
 
 ## Documentation
 

--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -105,8 +105,10 @@ This now matches the implemented minimal deferred path:
 - mesh nodes are accepted when they provide `POSITION` and `NORMAL`
 - built-in `unlit` material uniforms are written into a small G-buffer and resolved through a
   fullscreen lighting pass
-- SDF, volume, custom WGSL materials, and textured `baseColor` sampling remain outside the deferred
-  execution surface and fail preflight with explicit diagnostics
+- built-in `unlit` materials may also sample resident `baseColor` textures when meshes provide
+  `TEXCOORD_0`
+- SDF, volume, and custom WGSL materials remain outside the deferred execution surface and fail
+  preflight with explicit diagnostics
 
 ## Relationship To Other Specs
 

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -43,11 +43,13 @@ The initial renderer uses a lightweight pass graph:
 - Built-in unlit WGSL is stored as a standalone shader file and imported as text.
 - Built-in unlit shading supports color-only meshes plus optional base-color texture sampling when
   UVs and texture residency are available.
+- Built-in deferred unlit shading supports the same optional base-color texture sampling when
+  `NORMAL` and `TEXCOORD_0` data plus texture residency are available.
 - Built-in forward mesh draws upload each evaluated node `worldMatrix` and apply it in the vertex
   stage before rasterization.
 - Material parameter uploads and bind group creation are implemented for built-in unlit shading.
-- The minimal deferred path currently requires `NORMAL` vertex data and only accepts color-only
-  built-in `unlit` materials.
+- The minimal deferred path currently requires `NORMAL` vertex data and still limits materials to
+  built-in `unlit`, with optional base-color textures.
 - Custom WGSL programs can be registered and cached through the material registry.
 - Headless/offscreen rendering supports compact byte readback for snapshot testing.
 - Snapshot bytes can also be encoded into PNG for local inspection and regression workflows.
@@ -66,11 +68,15 @@ The initial renderer uses a lightweight pass graph:
 
 - Built-in forward mesh shaders reserve `@group(0) @binding(0)` for a `mat4x4<f32>` mesh transform
   uniform derived from the evaluated node world matrix.
+- Built-in deferred G-buffer mesh shaders reserve `@group(0) @binding(0)` for a transform uniform
+  containing the evaluated node world matrix plus an inverse-transpose normal matrix.
 - Material programs can declare `materialBindings` entries for uniform buffers, texture views, and
   samplers that are assembled into a single material bind group.
 - Built-in unlit material uniforms live at `@group(1) @binding(0)`.
 - Built-in textured unlit shading also binds base-color texture/view pairs at
   `@group(1) @binding(1)` and `@group(1) @binding(2)`.
+- Built-in deferred textured unlit shading uses the same `@group(1)` base-color texture/sampler
+  contract during G-buffer writes.
 - Custom WGSL programs that want the same evaluated mesh transform upload should register with
   `usesTransformBindings: true` and match the same `@group(0)` transform contract.
 - Custom WGSL programs that need sampled textures should declare matching texture/sampler bindings
@@ -88,7 +94,6 @@ The initial renderer uses a lightweight pass graph:
 
 ## Known Gaps
 
-- Deferred rendering does not yet cover textured materials, custom WGSL materials, SDF primitives,
-  or volume primitives.
+- Deferred rendering does not yet cover custom WGSL materials, SDF primitives, or volume primitives.
 - SDF execution currently supports sphere and box primitives only; broader graph/operator coverage
   is still pending.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -19,6 +19,9 @@ import builtInDeferredDepthPrepassShader from './shaders/built_in_deferred_depth
 import builtInDeferredGbufferUnlitShader from './shaders/built_in_deferred_gbuffer_unlit.wgsl' with {
   type: 'text',
 };
+import builtInDeferredGbufferTexturedUnlitShader from './shaders/built_in_deferred_gbuffer_unlit_textured.wgsl' with {
+  type: 'text',
+};
 import builtInDeferredLightingShader from './shaders/built_in_deferred_lighting.wgsl' with {
   type: 'text',
 };
@@ -179,6 +182,7 @@ const builtInUnlitProgramId = 'built-in:unlit';
 const builtInTexturedUnlitProgramId = 'built-in:unlit-textured';
 const builtInDeferredDepthPrepassProgramId = 'built-in:deferred-depth-prepass';
 const builtInDeferredGbufferUnlitProgramId = 'built-in:deferred-gbuffer-unlit';
+const builtInDeferredGbufferTexturedUnlitProgramId = 'built-in:deferred-gbuffer-unlit-textured';
 const builtInDeferredLightingProgramId = 'built-in:deferred-lighting';
 const builtInSdfRaymarchProgramId = 'built-in:sdf-raymarch';
 const builtInVolumeRaymarchProgramId = 'built-in:volume-raymarch';
@@ -291,6 +295,55 @@ const builtInDeferredGbufferUnlitProgram: MaterialProgram = {
       format: 'float32x3',
       offset: 0,
       arrayStride: 12,
+    },
+  ],
+};
+
+const builtInDeferredGbufferTexturedUnlitProgram: MaterialProgram = {
+  id: builtInDeferredGbufferTexturedUnlitProgramId,
+  label: 'Built-in Deferred G-buffer Unlit (Textured)',
+  wgsl: builtInDeferredGbufferTexturedUnlitShader,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  usesMaterialBindings: true,
+  usesTransformBindings: true,
+  materialBindings: [
+    {
+      kind: 'uniform',
+      binding: 0,
+    },
+    {
+      kind: 'texture',
+      binding: 1,
+      textureSemantic: 'baseColor',
+    },
+    {
+      kind: 'sampler',
+      binding: 2,
+      textureSemantic: 'baseColor',
+    },
+  ],
+  vertexAttributes: [
+    {
+      semantic: 'POSITION',
+      shaderLocation: 0,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'NORMAL',
+      shaderLocation: 1,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'TEXCOORD_0',
+      shaderLocation: 2,
+      format: 'float32x2',
+      offset: 0,
+      arrayStride: 8,
     },
   ],
 };
@@ -534,19 +587,6 @@ export const collectRendererCapabilityIssues = (
           'mesh',
           'vertex-attribute:NORMAL',
           `renderer "${renderer.label}" requires NORMAL vertex data on node "${node.node.id}" for deferred lighting`,
-        );
-      }
-
-      const unsupportedTexture = materialTextures.find((texture) =>
-        texture.semantic === 'baseColor'
-      );
-      if (unsupportedTexture) {
-        pushIssue(
-          'material-binding',
-          'texture-semantic:baseColor',
-          `renderer "${renderer.label}" does not support baseColor textures in the minimal deferred path for material "${
-            material?.id ?? createDefaultMaterial().id
-          }"`,
         );
       }
     }
@@ -926,8 +966,9 @@ export const ensureDeferredGbufferPipeline = (
   context: GpuRenderExecutionContext,
   residency: RuntimeResidency,
   format: GPUTextureFormat,
+  program: MaterialProgram = builtInDeferredGbufferUnlitProgram,
 ): GPURenderPipeline => {
-  const cacheKey = `${builtInDeferredGbufferUnlitProgramId}:${format}`;
+  const cacheKey = `${program.id}:${format}`;
   const cached = residency.pipelines.get(cacheKey);
   if (cached) {
     return cached as GPURenderPipeline;
@@ -935,19 +976,19 @@ export const ensureDeferredGbufferPipeline = (
 
   const shader = context.device.createShaderModule({
     label: cacheKey,
-    code: builtInDeferredGbufferUnlitShader,
+    code: program.wgsl,
   });
   const pipeline = context.device.createRenderPipeline({
     label: cacheKey,
     layout: 'auto',
     vertex: {
       module: shader,
-      entryPoint: 'vsMain',
-      buffers: createVertexBufferLayouts(builtInDeferredGbufferUnlitProgram.vertexAttributes),
+      entryPoint: program.vertexEntryPoint,
+      buffers: createVertexBufferLayouts(program.vertexAttributes),
     },
     fragment: {
       module: shader,
-      entryPoint: 'fsMain',
+      entryPoint: program.fragmentEntryPoint,
       targets: [{ format }, { format }],
     },
     primitive: {
@@ -1505,7 +1546,6 @@ export const renderDeferredFrame = (
     label: 'deferred-frame',
   });
   const depthPipeline = ensureDeferredDepthPrepassPipeline(context, residency);
-  const gbufferPipeline = ensureDeferredGbufferPipeline(context, residency, binding.target.format);
   const lightingPipeline = ensureDeferredLightingPipeline(
     context,
     residency,
@@ -1588,7 +1628,6 @@ export const renderDeferredFrame = (
       depthStoreOp: 'store',
     },
   });
-  gbufferPass.setPipeline(gbufferPipeline);
   for (const node of evaluatedScene.nodes) {
     const mesh = node.mesh;
     if (!mesh) {
@@ -1596,14 +1635,43 @@ export const renderDeferredFrame = (
     }
 
     const geometry = residency.geometry.get(mesh.id);
-    const positionBuffer = geometry?.attributeBuffers.POSITION;
-    const normalBuffer = geometry?.attributeBuffers.NORMAL;
-    if (!geometry || !positionBuffer || !normalBuffer) {
+    if (!geometry) {
       continue;
     }
 
-    gbufferPass.setVertexBuffer(0, positionBuffer);
-    gbufferPass.setVertexBuffer(1, normalBuffer);
+    const material = node.material ?? createDefaultMaterial();
+    const baseColorTexture = getBaseColorTextureResidency(residency, material);
+    const gbufferProgram = baseColorTexture && geometry.attributeBuffers.TEXCOORD_0
+      ? builtInDeferredGbufferTexturedUnlitProgram
+      : builtInDeferredGbufferUnlitProgram;
+    const gbufferPipeline = ensureDeferredGbufferPipeline(
+      context,
+      residency,
+      binding.target.format,
+      gbufferProgram,
+    );
+
+    let isDrawable = true;
+    for (let index = 0; index < gbufferProgram.vertexAttributes.length; index += 1) {
+      const attribute = gbufferProgram.vertexAttributes[index];
+      if (attribute.offset !== 0) {
+        isDrawable = false;
+        break;
+      }
+
+      const buffer = geometry.attributeBuffers[attribute.semantic];
+      if (!buffer) {
+        isDrawable = false;
+        break;
+      }
+
+      gbufferPass.setVertexBuffer(index, buffer);
+    }
+    if (!isDrawable) {
+      continue;
+    }
+
+    gbufferPass.setPipeline(gbufferPipeline);
 
     const transformData = createDeferredMeshTransformUniformData(node.worldMatrix);
     const transformBuffer = context.device.createBuffer({
@@ -1625,18 +1693,23 @@ export const renderDeferredFrame = (
       }),
     );
 
-    const material = node.material ?? createDefaultMaterial();
-    const materialResidency = ensureMaterialResidency(context, residency, material);
+    const materialBindings = getMaterialBindingDescriptors(gbufferProgram);
+    const materialResidency = {
+      current: undefined as ReturnType<typeof ensureMaterialResidency> | undefined,
+    };
     gbufferPass.setBindGroup(
       1,
       context.device.createBindGroup({
         layout: gbufferPipeline.getBindGroupLayout(1),
-        entries: [{
-          binding: 0,
-          resource: {
-            buffer: materialResidency.uniformBuffer,
-          },
-        }],
+        entries: materialBindings.map((descriptor) =>
+          resolveMaterialBindingResource(
+            context,
+            residency,
+            material,
+            descriptor,
+            materialResidency,
+          )
+        ),
       }),
     );
 

--- a/packages/renderer/src/shaders/built_in_deferred_gbuffer_unlit_textured.wgsl
+++ b/packages/renderer/src/shaders/built_in_deferred_gbuffer_unlit_textured.wgsl
@@ -1,0 +1,46 @@
+struct MeshTransform {
+  world: mat4x4<f32>,
+  normalMatrix: mat4x4<f32>,
+};
+
+struct MaterialUniforms {
+  values: array<vec4<f32>, 16>,
+};
+
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) normal: vec3<f32>,
+  @location(1) texCoord: vec2<f32>,
+};
+
+struct GbufferOut {
+  @location(0) albedo: vec4<f32>,
+  @location(1) normal: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> meshTransform: MeshTransform;
+@group(1) @binding(0) var<uniform> material: MaterialUniforms;
+@group(1) @binding(1) var baseColorTexture: texture_2d<f32>;
+@group(1) @binding(2) var baseColorSampler: sampler;
+
+@vertex
+fn vsMain(
+  @location(0) position: vec3<f32>,
+  @location(1) normal: vec3<f32>,
+  @location(2) texCoord: vec2<f32>,
+) -> VsOut {
+  var out: VsOut;
+  let worldNormal = normalize((meshTransform.normalMatrix * vec4<f32>(normal, 0.0)).xyz);
+  out.position = meshTransform.world * vec4<f32>(position, 1.0);
+  out.normal = worldNormal;
+  out.texCoord = texCoord;
+  return out;
+}
+
+@fragment
+fn fsMain(in: VsOut) -> GbufferOut {
+  var out: GbufferOut;
+  out.albedo = material.values[0] * textureSample(baseColorTexture, baseColorSampler, in.texCoord);
+  out.normal = vec4<f32>((normalize(in.normal) * 0.5) + vec3<f32>(0.5), 1.0);
+  return out;
+}

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -303,7 +303,11 @@ Deno.test('renderDeferredFrame encodes depth, gbuffer, and lighting passes for m
   );
   assertEquals(mocks.bindGroupEntries.length, 4);
   assertEquals(mocks.samplers.length, 1);
-  const deferredVertexBuffers = mocks.pipelines[1].descriptor.vertex?.buffers ?? [];
+  const deferredGbufferPipeline = mocks.pipelines.find((pipeline) =>
+    pipeline.descriptor.fragment?.targets?.length === 2
+  );
+  assertEquals(deferredGbufferPipeline?.descriptor.fragment?.targets?.length, 2);
+  const deferredVertexBuffers = deferredGbufferPipeline?.descriptor.vertex?.buffers ?? [];
   assertEquals(deferredVertexBuffers.length, 2);
   assertEquals(
     deferredVertexBuffers.map((buffer) => buffer?.attributes.length ?? 0),
@@ -357,6 +361,86 @@ Deno.test('renderDeferredFrame encodes depth, gbuffer, and lighting passes for m
     ),
     Array.from(expectedDeferredTransform),
   );
+});
+
+Deno.test('renderDeferredFrame binds base-color textures for textured deferred unlit materials', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-textured',
+    kind: 'unlit',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {
+      color: { x: 1, y: 1, z: 1, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-textured-deferred',
+    materialId: 'material-textured',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(
+    scene,
+    createNode('node-textured-deferred', { meshId: 'mesh-textured-deferred' }),
+  );
+
+  runtimeResidency.geometry.set('mesh-textured-deferred', {
+    meshId: 'mesh-textured-deferred',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      NORMAL: { id: 1 } as unknown as GPUBuffer,
+      TEXCOORD_0: { id: 2 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  runtimeResidency.textures.set('texture-0', {
+    textureId: 'texture-0',
+    texture: { id: 0 } as unknown as GPUTexture,
+    view: { id: 0 } as unknown as GPUTextureView,
+    sampler: { id: 0 } as unknown as GPUSampler,
+    width: 2,
+    height: 2,
+    format: 'rgba8unorm-srgb',
+  });
+
+  const binding = createOffscreenContext({
+    device: mocks.device as unknown as GPUDevice,
+    target: createHeadlessTarget(64, 64),
+  });
+
+  const result = renderDeferredFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    binding,
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(result.drawCount, 3);
+  assertEquals(mocks.pipelines.length, 3);
+  const deferredGbufferPipeline = mocks.pipelines.find((pipeline) =>
+    pipeline.descriptor.fragment?.targets?.length === 2
+  );
+  assertEquals(deferredGbufferPipeline?.descriptor.fragment?.targets?.length, 2);
+  const deferredVertexBuffers = deferredGbufferPipeline?.descriptor.vertex?.buffers ?? [];
+  assertEquals(deferredVertexBuffers.length, 3);
+  assertEquals(
+    deferredVertexBuffers.map((buffer) => buffer?.attributes[0]?.shaderLocation ?? -1),
+    [0, 1, 2],
+  );
+  assertEquals(mocks.bindGroupEntries.length, 4);
+  assertEquals(mocks.bindGroupEntries[2].map((entry) => entry.binding), [0, 1, 2]);
 });
 
 Deno.test('renderForwardFrame encodes a dedicated sdf raymarch pass for supported sphere and box nodes', () => {

--- a/tests/headless_snapshot_test.ts
+++ b/tests/headless_snapshot_test.ts
@@ -6,7 +6,7 @@ import {
   createOffscreenReadbackPlan,
   createRuntimeResidency,
 } from '@rieul3d/gpu';
-import { appendMesh, appendNode, createNode, createSceneIr } from '@rieul3d/ir';
+import { appendMaterial, appendMesh, appendNode, createNode, createSceneIr } from '@rieul3d/ir';
 import { renderDeferredSnapshot, renderForwardSnapshot } from '@rieul3d/renderer';
 import { createHeadlessTarget } from '@rieul3d/platform';
 
@@ -256,4 +256,76 @@ Deno.test('renderDeferredSnapshot returns compact offscreen bytes for minimal de
     width: 2,
     height: 2,
   }]);
+});
+
+Deno.test('renderDeferredSnapshot also accepts textured deferred scenes with resident baseColor data', async () => {
+  const mocks = createSnapshotMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-textured',
+    kind: 'unlit',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {
+      color: { x: 1, y: 1, z: 1, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh',
+    materialId: 'material-textured',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('node', { meshId: 'mesh' }));
+
+  runtimeResidency.geometry.set('mesh', {
+    meshId: 'mesh',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      NORMAL: { id: 1 } as unknown as GPUBuffer,
+      TEXCOORD_0: { id: 2 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  runtimeResidency.textures.set('texture-0', {
+    textureId: 'texture-0',
+    texture: {} as GPUTexture,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 2,
+    height: 2,
+    format: 'rgba8unorm-srgb',
+  });
+
+  const binding = createOffscreenContext({
+    device: mocks.device as unknown as GPUDevice,
+    target: createHeadlessTarget(2, 2),
+  });
+
+  const snapshot = await renderDeferredSnapshot(
+    mocks as unknown as Parameters<typeof renderDeferredSnapshot>[0],
+    binding,
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(snapshot.drawCount, 3);
+  assertEquals(snapshot.submittedCommandBufferCount, 1);
+  assertEquals(snapshot.width, 2);
+  assertEquals(snapshot.height, 2);
+  assertEquals(
+    [...snapshot.bytes],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  );
+  assertEquals(mocks.submits.length, 2);
 });

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -505,7 +505,54 @@ Deno.test('deferred renderer accepts minimal mesh/unlit scenes with normals', ()
   assertEquals(issues, []);
 });
 
-Deno.test('deferred renderer rejects missing normals and textured unlit materials during preflight', () => {
+Deno.test('deferred renderer accepts textured unlit scenes with normals, uvs, and resident textures', () => {
+  const residency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-textured',
+    kind: 'unlit',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {
+      color: { x: 1, y: 1, z: 1, w: 1 },
+    },
+  });
+  residency.textures.set('texture-0', {
+    textureId: 'texture-0',
+    texture: {} as GPUTexture,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 2,
+    height: 2,
+    format: 'rgba8unorm-srgb',
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-textured',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+
+  const issues = collectRendererCapabilityIssues(
+    createDeferredRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+    createMaterialRegistry(),
+    residency,
+  );
+
+  assertEquals(issues, []);
+});
+
+Deno.test('deferred renderer rejects textured unlit scenes that omit normals or uvs during preflight', () => {
   let scene = createSceneIr('scene');
   scene = appendMaterial(scene, {
     id: 'material-textured',
@@ -526,7 +573,6 @@ Deno.test('deferred renderer rejects missing normals and textured unlit material
     materialId: 'material-textured',
     attributes: [
       { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
-      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
     ],
   });
   scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
@@ -547,9 +593,9 @@ Deno.test('deferred renderer rejects missing normals and textured unlit material
     {
       nodeId: 'mesh-node',
       feature: 'material-binding',
-      requirement: 'texture-semantic:baseColor',
+      requirement: 'vertex-attribute:TEXCOORD_0',
       message:
-        'renderer "deferred" does not support baseColor textures in the minimal deferred path for material "material-textured"',
+        'renderer "deferred" cannot sample baseColor textures on node "mesh-node" because mesh "mesh-0" is missing TEXCOORD_0',
     },
   ]);
 });


### PR DESCRIPTION
## Summary
- add a textured deferred G-buffer unlit program that samples resident baseColor textures when NORMAL and TEXCOORD_0 data are available
- route deferred preflight and frame encoding through the same residency-aware material binding rules used by forward rendering
- extend renderer, headless snapshot, and documentation coverage for textured deferred scenes

## Testing
- deno test --unstable-raw-imports tests/renderer_test.ts tests/forward_render_test.ts tests/headless_snapshot_test.ts
- deno task docs:check
- deno task check

Refs #66