### PR TITLE
Add first-class directional lighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Implemented today:
 - BDL-driven `SceneIr` generation with drift checks in CI
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
 - forward rendering, minimal deferred mesh/unlit execution with optional baseColor texture sampling,
-  first SDF raymarch execution, and headless snapshot readback
+  first-class directional light nodes with built-in forward Lambert shading, first SDF raymarch
+  execution, and headless snapshot readback
 - forward SDF sphere and box raymarch execution with capability preflight alignment
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
   sampling, material parameter uploads, custom WGSL registration, declared material texture

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Use this page as the main navigation hub.
 
 - Understand the system shape: [`specs/architecture.md`](./specs/architecture.md)
 - Understand the scene data model: [`specs/scene-ir.md`](./specs/scene-ir.md)
+- Understand the renderer light and material support surface:
+  [`specs/rendering.md`](./specs/rendering.md)
 - Understand runtime GPU ownership and recovery:
   [`specs/runtime-residency.md`](./specs/runtime-residency.md)
 - Understand device-loss handling and caller recovery steps:

--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -15,6 +15,7 @@ The capability model exists to answer two questions early:
 Each renderer advertises a `capabilities` object with:
 
 - primitive support states for `mesh`, `sdf`, and `volume`
+- scene-light support state for evaluated light nodes
 - the list of built-in material kinds it accepts
 - a support state for custom WGSL shader programs
 
@@ -24,6 +25,7 @@ The current TypeScript surface is:
 - `RendererCapabilities.mesh`
 - `RendererCapabilities.sdf`
 - `RendererCapabilities.volume`
+- `RendererCapabilities.light`
 - `RendererCapabilities.builtInMaterialKinds`
 - `RendererCapabilities.customShaders`
 
@@ -47,9 +49,11 @@ The current preflight rules are:
 - mesh nodes require `capabilities.mesh === 'supported'`
 - SDF nodes require `capabilities.sdf === 'supported'`
 - volume nodes require `capabilities.volume === 'supported'`
+- light nodes require `capabilities.light === 'supported'`
 - built-in materials without `shaderId` must have `material.kind` listed in
   `capabilities.builtInMaterialKinds`
 - materials with `shaderId` require `capabilities.customShaders === 'supported'`
+- built-in `lit` materials also require at least one directional light plus `NORMAL` mesh data
 
 Renderers may apply narrower execution limits after the top-level capability gate. For example, the
 forward renderer currently advertises SDF support but only encodes sphere and box SDF primitives;
@@ -84,11 +88,12 @@ The current forward renderer declares:
 - `mesh: supported`
 - `sdf: supported`
 - `volume: supported`
-- `builtInMaterialKinds: ['unlit']`
+- `light: supported`
+- `builtInMaterialKinds: ['unlit', 'lit']`
 - `customShaders: supported`
 
-This matches the implemented path: mesh draws plus first SDF and volume raymarch passes are encoded
-in the forward renderer.
+This matches the implemented path: mesh draws, directional-light Lambert shading, plus first SDF and
+volume raymarch passes are encoded in the forward renderer.
 
 ### Deferred
 
@@ -97,6 +102,7 @@ The deferred renderer declares:
 - `mesh: supported`
 - `sdf: unsupported`
 - `volume: unsupported`
+- `light: unsupported`
 - `builtInMaterialKinds: ['unlit']`
 - `customShaders: unsupported`
 

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -35,18 +35,26 @@ The initial renderer uses a lightweight pass graph:
 ## Current Execution Surface
 
 - Forward rendering is the first concrete execution path and currently draws mesh residency items.
+- Forward rendering now also consumes first-class directional light nodes for built-in Lambert mesh
+  shading.
 - Deferred rendering now executes a minimal mesh-only path with a depth prepass, an unlit
   albedo/normal G-buffer pass, and a fullscreen lighting resolve.
 - Forward rendering also encodes a dedicated SDF raymarch pass for supported sphere and box
   primitives.
 - Forward rendering also encodes a first volume raymarch pass for volume primitives with residency.
 - Built-in unlit WGSL is stored as a standalone shader file and imported as text.
+- Built-in forward lit WGSL is stored as a standalone shader file and consumes directional-light
+  uniform data extracted from evaluated light nodes.
 - Built-in unlit shading supports color-only meshes plus optional base-color texture sampling when
   UVs and texture residency are available.
+- Built-in lit shading currently supports color-only Lambert materials that require mesh normals and
+  at least one directional light.
 - Built-in deferred unlit shading supports the same optional base-color texture sampling when
   `NORMAL` and `TEXCOORD_0` data plus texture residency are available.
 - Built-in forward mesh draws upload each evaluated node `worldMatrix` and apply it in the vertex
   stage before rasterization.
+- Built-in forward lit mesh draws also upload an inverse-transpose normal matrix plus a compact
+  directional-light uniform block.
 - Material parameter uploads and bind group creation are implemented for built-in unlit shading.
 - The minimal deferred path currently requires `NORMAL` vertex data and still limits materials to
   built-in `unlit`, with optional base-color textures.
@@ -95,5 +103,6 @@ The initial renderer uses a lightweight pass graph:
 ## Known Gaps
 
 - Deferred rendering does not yet cover custom WGSL materials, SDF primitives, or volume primitives.
+- Deferred rendering does not yet consume Scene IR light nodes or built-in lit materials.
 - SDF execution currently supports sphere and box primitives only; broader graph/operator coverage
   is still pending.

--- a/docs/specs/scene-ir.md
+++ b/docs/specs/scene-ir.md
@@ -17,8 +17,8 @@ standard and declares that explicitly with `# standard - conventional`.
 ## Core Concepts
 
 - Assets describe external source data such as images, geometry files, or volume grids.
-- Scene IR describes spatial declarations: nodes, primitives, materials, textures, animations, and
-  graph bindings.
+- Scene IR describes spatial declarations: nodes, primitives, materials, lights, textures,
+  animations, and graph bindings.
 - IR does not contain `GPUBuffer`, `GPUTexture`, pipelines, or frame scratch state.
 
 ## Spatial Primitives
@@ -26,6 +26,8 @@ standard and declares that explicitly with `# standard - conventional`.
 - `mesh`: indexed or non-indexed polygonal geometry
 - `sdf`: signed distance field graphs or primitives for raymarching
 - `volume`: voxel or density grid primitives
+- `light`: first-class scene lights attached to nodes; the initial renderer consumes directional
+  lights through node transforms
 
 ## Evaluation
 

--- a/examples/browser_forward/README.md
+++ b/examples/browser_forward/README.md
@@ -2,6 +2,8 @@
 
 This is the main runnable example for the current renderer scaffold.
 
+It renders a triangle through the built-in forward Lambert path with a Scene IR directional light.
+
 Build the example bundle:
 
 ```sh

--- a/examples/browser_forward/main.ts
+++ b/examples/browser_forward/main.ts
@@ -7,7 +7,14 @@ import {
   ensureSceneMeshResidency,
   requestGpuContext,
 } from '../../packages/gpu/mod.ts';
-import { appendMesh, appendNode, createNode, createSceneIr } from '../../packages/ir/mod.ts';
+import {
+  appendLight,
+  appendMaterial,
+  appendMesh,
+  appendNode,
+  createNode,
+  createSceneIr,
+} from '../../packages/ir/mod.ts';
 import { createBrowserSurfaceTarget } from '../../packages/platform/mod.ts';
 import { createMaterialRegistry, renderForwardFrame } from '../../packages/renderer/mod.ts';
 
@@ -20,24 +27,65 @@ canvas.width = 640;
 canvas.height = 480;
 
 const scene = appendNode(
-  appendMesh(createSceneIr('browser-forward'), {
-    id: 'triangle',
-    attributes: [{
-      semantic: 'POSITION',
-      itemSize: 3,
-      values: [
-        0,
-        0.7,
-        0,
-        -0.7,
-        -0.7,
-        0,
-        0.7,
-        -0.7,
-        0,
-      ],
-    }],
-  }),
+  appendNode(
+    appendMesh(
+      appendMaterial(
+        appendLight(createSceneIr('browser-forward'), {
+          id: 'key-light',
+          kind: 'directional',
+          color: { x: 1, y: 0.95, z: 0.9 },
+          intensity: 1.4,
+        }),
+        {
+          id: 'triangle-material',
+          kind: 'lit',
+          textures: [],
+          parameters: {
+            color: { x: 0.92, y: 0.42, z: 0.22, w: 1 },
+          },
+        },
+      ),
+      {
+        id: 'triangle',
+        materialId: 'triangle-material',
+        attributes: [
+          {
+            semantic: 'POSITION',
+            itemSize: 3,
+            values: [
+              0,
+              0.7,
+              0,
+              -0.7,
+              -0.7,
+              0,
+              0.7,
+              -0.7,
+              0,
+            ],
+          },
+          {
+            semantic: 'NORMAL',
+            itemSize: 3,
+            values: [
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+            ],
+          },
+        ],
+      },
+    ),
+    createNode('light-node', {
+      lightId: 'key-light',
+    }),
+  ),
   createNode('triangle-node', {
     meshId: 'triangle',
   }),

--- a/packages/core/src/evaluate_scene.ts
+++ b/packages/core/src/evaluate_scene.ts
@@ -1,5 +1,6 @@
 import type {
   AnimationChannel,
+  Light,
   Material,
   MeshPrimitive,
   Node,
@@ -17,6 +18,7 @@ export type EvaluatedNode = Readonly<{
   material?: Material;
   sdf?: SdfPrimitive;
   volume?: VolumePrimitive;
+  light?: Light;
 }>;
 
 export type EvaluatedScene = Readonly<{
@@ -155,6 +157,11 @@ const applyAnimation = (scene: SceneIr, options: EvaluateSceneOptions): readonly
 export const evaluateScene = (scene: SceneIr, options: EvaluateSceneOptions): EvaluatedScene => {
   const nodes = applyAnimation(scene, options);
   const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const meshById = new Map(scene.meshes.map((mesh) => [mesh.id, mesh]));
+  const materialById = new Map(scene.materials.map((material) => [material.id, material]));
+  const sdfById = new Map(scene.sdfPrimitives.map((primitive) => [primitive.id, primitive]));
+  const volumeById = new Map(scene.volumePrimitives.map((primitive) => [primitive.id, primitive]));
+  const lightById = new Map(scene.lights.map((light) => [light.id, light]));
   const worldById = new Map<string, Mat4>();
 
   const getWorldMatrix = (node: Node): Mat4 => {
@@ -171,25 +178,18 @@ export const evaluateScene = (scene: SceneIr, options: EvaluateSceneOptions): Ev
   return {
     sceneId: scene.id,
     timeMs: options.timeMs,
-    nodes: nodes.map((node) => ({
-      node,
-      worldMatrix: getWorldMatrix(node),
-      mesh: node.meshId ? scene.meshes.find((mesh) => mesh.id === node.meshId) : undefined,
-      material: node.meshId
-        ? (() => {
-          const mesh = scene.meshes.find((candidate) => candidate.id === node.meshId);
-          return mesh?.materialId
-            ? scene.materials.find((material) => material.id === mesh.materialId)
-            : undefined;
-        })()
-        : undefined,
-      sdf: node.sdfId
-        ? scene.sdfPrimitives.find((primitive) => primitive.id === node.sdfId)
-        : undefined,
-      volume: node.volumeId
-        ? scene.volumePrimitives.find((primitive) => primitive.id === node.volumeId)
-        : undefined,
-    })),
+    nodes: nodes.map((node) => {
+      const mesh = node.meshId ? meshById.get(node.meshId) : undefined;
+      return {
+        node,
+        worldMatrix: getWorldMatrix(node),
+        mesh,
+        material: mesh?.materialId ? materialById.get(mesh.materialId) : undefined,
+        sdf: node.sdfId ? sdfById.get(node.sdfId) : undefined,
+        volume: node.volumeId ? volumeById.get(node.volumeId) : undefined,
+        light: node.lightId ? lightById.get(node.lightId) : undefined,
+      };
+    }),
   };
 };
 

--- a/packages/ir/schema/scene_ir.bdl
+++ b/packages/ir/schema/scene_ir.bdl
@@ -59,6 +59,13 @@ struct Material {
   parameters: Vec4[string],
 }
 
+struct Light {
+  id: Id,
+  kind: string,
+  color: Vec3,
+  intensity: Scalar,
+}
+
 struct MeshAttribute {
   semantic: string,
   itemSize: int32,
@@ -93,6 +100,7 @@ struct Node {
   meshId?: Id,
   sdfId?: Id,
   volumeId?: Id,
+  lightId?: Id,
 }
 
 struct AnimationKeyframe {
@@ -118,6 +126,7 @@ struct SceneIr {
   assets: AssetRef[],
   textures: TextureRef[],
   materials: Material[],
+  lights: Light[],
   meshes: MeshPrimitive[],
   sdfPrimitives: SdfPrimitive[],
   volumePrimitives: VolumePrimitive[],

--- a/packages/ir/src/generated/scene_ir.generated.ts
+++ b/packages/ir/src/generated/scene_ir.generated.ts
@@ -58,6 +58,13 @@ export type Material = Readonly<{
   parameters: Readonly<Record<string, Vec4>>;
 }>;
 
+export type Light = Readonly<{
+  id: Id;
+  kind: string;
+  color: Vec3;
+  intensity: Scalar;
+}>;
+
 export type MeshAttribute = Readonly<{
   semantic: string;
   itemSize: number;
@@ -92,6 +99,7 @@ export type Node = Readonly<{
   meshId?: Id;
   sdfId?: Id;
   volumeId?: Id;
+  lightId?: Id;
 }>;
 
 export type AnimationKeyframe = Readonly<{
@@ -117,6 +125,7 @@ export type SceneIr = Readonly<{
   assets: readonly AssetRef[];
   textures: readonly TextureRef[];
   materials: readonly Material[];
+  lights: readonly Light[];
   meshes: readonly MeshPrimitive[];
   sdfPrimitives: readonly SdfPrimitive[];
   volumePrimitives: readonly VolumePrimitive[];

--- a/packages/ir/src/scene_ir.ts
+++ b/packages/ir/src/scene_ir.ts
@@ -1,5 +1,6 @@
 import type {
   AnimationClip,
+  Light,
   Material,
   MeshPrimitive,
   Node,
@@ -22,6 +23,7 @@ export const createSceneIr = (id = 'scene'): SceneIr => ({
   assets: [],
   textures: [],
   materials: [],
+  lights: [],
   meshes: [],
   sdfPrimitives: [],
   volumePrimitives: [],
@@ -60,6 +62,11 @@ export const appendMaterial = (scene: SceneIr, material: Material): SceneIr => (
   materials: [...scene.materials, material],
 });
 
+export const appendLight = (scene: SceneIr, light: Light): SceneIr => ({
+  ...scene,
+  lights: [...scene.lights, light],
+});
+
 export const appendAnimationClip = (scene: SceneIr, clip: AnimationClip): SceneIr => ({
   ...scene,
   animationClips: [...scene.animationClips, clip],
@@ -70,6 +77,7 @@ export const validateSceneIr = (
 ): { ok: true } | { ok: false; issues: string[] } => {
   const issues: string[] = [];
   const nodeIds = new Set(scene.nodes.map((node) => node.id));
+  const lightIds = new Set(scene.lights.map((light) => light.id));
 
   for (const rootNodeId of scene.rootNodeIds) {
     if (!nodeIds.has(rootNodeId)) {
@@ -80,6 +88,9 @@ export const validateSceneIr = (
   for (const node of scene.nodes) {
     if (node.parentId && !nodeIds.has(node.parentId)) {
       issues.push(`node "${node.id}" references missing parent "${node.parentId}"`);
+    }
+    if (node.lightId && !lightIds.has(node.lightId)) {
+      issues.push(`node "${node.id}" references missing light "${node.lightId}"`);
     }
   }
 

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -10,6 +10,7 @@ import {
   type TextureResidency,
 } from '@rieul3d/gpu';
 import builtInForwardShader from './shaders/built_in_forward_unlit.wgsl' with { type: 'text' };
+import builtInForwardLitShader from './shaders/built_in_forward_lit.wgsl' with { type: 'text' };
 import builtInForwardTexturedShader from './shaders/built_in_forward_unlit_textured.wgsl' with {
   type: 'text',
 };
@@ -52,6 +53,7 @@ export type RendererCapabilities = Readonly<{
   mesh: CapabilityState;
   sdf: CapabilityState;
   volume: CapabilityState;
+  light: CapabilityState;
   builtInMaterialKinds: readonly string[];
   customShaders: CapabilityState;
 }>;
@@ -173,12 +175,28 @@ export type SdfPassItem = Readonly<{
 
 export type RendererCapabilityIssue = Readonly<{
   nodeId: string;
-  feature: 'mesh' | 'sdf' | 'volume' | 'material-kind' | 'custom-shader' | 'material-binding';
+  feature:
+    | 'mesh'
+    | 'sdf'
+    | 'volume'
+    | 'light'
+    | 'material-kind'
+    | 'custom-shader'
+    | 'material-binding';
   requirement: string;
   message: string;
 }>;
 
+export type DirectionalLightItem = Readonly<{
+  nodeId: string;
+  lightId: string;
+  direction: readonly [number, number, number];
+  color: readonly [number, number, number];
+  intensity: number;
+}>;
+
 const builtInUnlitProgramId = 'built-in:unlit';
+const builtInLitProgramId = 'built-in:lit';
 const builtInTexturedUnlitProgramId = 'built-in:unlit-textured';
 const builtInDeferredDepthPrepassProgramId = 'built-in:deferred-depth-prepass';
 const builtInDeferredGbufferUnlitProgramId = 'built-in:deferred-gbuffer-unlit';
@@ -192,6 +210,8 @@ const uniformUsage = 0x40;
 const bufferCopyDstUsage = 0x08;
 const deferredDepthFormat = 'depth24plus';
 const maxSdfPassItems = 16;
+const maxDirectionalLights = 4;
+const defaultAmbientLight = 0.2;
 const toBufferSource = (view: ArrayBufferView): Uint8Array<ArrayBuffer> => {
   const buffer = view.buffer.slice(
     view.byteOffset,
@@ -225,6 +245,36 @@ const builtInUnlitProgram: MaterialProgram = {
     offset: 0,
     arrayStride: 12,
   }],
+};
+
+const builtInLitProgram: MaterialProgram = {
+  id: builtInLitProgramId,
+  label: 'Built-in Lit',
+  wgsl: builtInForwardLitShader,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  usesMaterialBindings: true,
+  usesTransformBindings: true,
+  materialBindings: [{
+    kind: 'uniform',
+    binding: 0,
+  }],
+  vertexAttributes: [
+    {
+      semantic: 'POSITION',
+      shaderLocation: 0,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'NORMAL',
+      shaderLocation: 1,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+  ],
 };
 
 const builtInTexturedUnlitProgram: MaterialProgram = {
@@ -364,6 +414,7 @@ const createVertexBufferLayouts = (
 export const createMaterialRegistry = (): MaterialRegistry => ({
   programs: new Map([
     [builtInUnlitProgramId, builtInUnlitProgram],
+    [builtInLitProgramId, builtInLitProgram],
     [builtInTexturedUnlitProgramId, builtInTexturedUnlitProgram],
   ]),
 });
@@ -402,6 +453,10 @@ export const resolveMaterialProgram = (
       return registry.programs.get(builtInTexturedUnlitProgramId) ?? builtInTexturedUnlitProgram;
     }
     return registry.programs.get(builtInUnlitProgramId) ?? builtInUnlitProgram;
+  }
+
+  if (material.kind === 'lit') {
+    return registry.programs.get(builtInLitProgramId) ?? builtInLitProgram;
   }
 
   throw new Error(`material "${material.id}" uses unsupported kind "${material.kind}"`);
@@ -493,7 +548,8 @@ export const createForwardRenderer = (label = 'forward'): Renderer => ({
     mesh: 'supported',
     sdf: 'supported',
     volume: 'supported',
-    builtInMaterialKinds: ['unlit'],
+    light: 'supported',
+    builtInMaterialKinds: ['unlit', 'lit'],
     customShaders: 'supported',
   },
   passes: [
@@ -510,6 +566,7 @@ export const createDeferredRenderer = (label = 'deferred'): Renderer => ({
     mesh: 'supported',
     sdf: 'unsupported',
     volume: 'unsupported',
+    light: 'unsupported',
     builtInMaterialKinds: ['unlit'],
     customShaders: 'unsupported',
   },
@@ -615,6 +672,14 @@ export const collectRendererCapabilityIssues = (
       );
     }
 
+    if (node.light && renderer.capabilities.light !== 'supported') {
+      pushIssue(
+        'light',
+        'light-execution',
+        `renderer "${renderer.label}" does not support scene light execution`,
+      );
+    }
+
     if (
       material &&
       !material.shaderId &&
@@ -692,6 +757,38 @@ export const collectRendererCapabilityIssues = (
           'material-binding',
           'texture-residency:baseColor:texture',
           `renderer "${renderer.label}" cannot sample baseColor textures for material "${material.id}" because texture "${baseColorTexture.id}" is not resident`,
+        );
+      }
+    } else if (material?.kind === 'lit') {
+      if (renderer.capabilities.light !== 'supported') {
+        pushIssue(
+          'light',
+          'light-material:lit',
+          `renderer "${renderer.label}" does not support built-in lit materials`,
+        );
+      }
+
+      if (!evaluatedScene.nodes.some((candidate) => candidate.light?.kind === 'directional')) {
+        pushIssue(
+          'light',
+          'light-source:directional',
+          `renderer "${renderer.label}" requires at least one directional light for material "${material.id}"`,
+        );
+      }
+
+      if (materialTextures.length > 0) {
+        pushIssue(
+          'material-binding',
+          'light-material:textures-unsupported',
+          `renderer "${renderer.label}" does not yet support textures on built-in lit material "${material.id}"`,
+        );
+      }
+
+      if (node.mesh && !node.mesh.attributes.some((attribute) => attribute.semantic === 'NORMAL')) {
+        pushIssue(
+          'material-binding',
+          'vertex-attribute:NORMAL',
+          `renderer "${renderer.label}" cannot light node "${node.node.id}" because mesh "${node.mesh.id}" is missing NORMAL`,
         );
       }
     }
@@ -911,6 +1008,55 @@ export const extractSdfPassItems = (
       worldToLocalRotation: getWorldToLocalRotation(node.worldMatrix),
     }];
   });
+
+export const extractDirectionalLightItems = (
+  evaluatedScene: EvaluatedScene,
+): readonly DirectionalLightItem[] =>
+  evaluatedScene.nodes.flatMap((node) => {
+    if (!node.light || node.light.kind !== 'directional') {
+      return [];
+    }
+
+    const [x, y, z] = normalizeVector3(
+      -(node.worldMatrix[8] ?? 0),
+      -(node.worldMatrix[9] ?? 0),
+      -(node.worldMatrix[10] ?? 1),
+    );
+    const direction: readonly [number, number, number] = x === 0 && y === 0 && z === 0
+      ? [0, 0, -1]
+      : [x, y, z];
+
+    return [{
+      nodeId: node.node.id,
+      lightId: node.light.id,
+      direction,
+      color: [node.light.color.x, node.light.color.y, node.light.color.z],
+      intensity: node.light.intensity,
+    }];
+  });
+
+const createDirectionalLightUniformData = (
+  lights: readonly DirectionalLightItem[],
+): Float32Array => {
+  const uniformData = new Float32Array((maxDirectionalLights * 8) + 4);
+  const clampedLights = lights.slice(0, maxDirectionalLights);
+
+  for (let index = 0; index < clampedLights.length; index += 1) {
+    const light = clampedLights[index];
+    const baseIndex = index * 4;
+    uniformData.set(light.direction, baseIndex);
+    uniformData.set(light.color, (maxDirectionalLights * 4) + baseIndex);
+    uniformData[(maxDirectionalLights * 4) + baseIndex + 3] = light.intensity;
+  }
+
+  const settingsOffset = maxDirectionalLights * 8;
+  uniformData[settingsOffset] = clampedLights.length;
+  uniformData[settingsOffset + 1] = defaultAmbientLight;
+  return uniformData;
+};
+
+const usesLitMaterialProgram = (program: MaterialProgram): boolean =>
+  program.id === builtInLitProgramId;
 
 export const ensureBuiltInForwardPipeline = (
   context: GpuRenderExecutionContext,
@@ -1375,6 +1521,7 @@ export const renderForwardFrame = (
   });
 
   let drawCount = 0;
+  const directionalLights = extractDirectionalLightItems(evaluatedScene);
   for (const node of evaluatedScene.nodes) {
     const mesh = node.mesh;
     if (!mesh) {
@@ -1423,7 +1570,9 @@ export const renderForwardFrame = (
     pass.setPipeline(pipeline);
 
     if (program.usesTransformBindings) {
-      const transformData = createMeshTransformUniformData(node.worldMatrix);
+      const transformData = usesLitMaterialProgram(program)
+        ? createDeferredMeshTransformUniformData(node.worldMatrix)
+        : createMeshTransformUniformData(node.worldMatrix);
       const transformBuffer = context.device.createBuffer({
         label: `${node.node.id}:mesh-transform`,
         size: transformData.byteLength,
@@ -1461,6 +1610,28 @@ export const renderForwardFrame = (
         ),
       });
       pass.setBindGroup(materialBindGroupIndex, bindGroup);
+    }
+
+    if (usesLitMaterialProgram(program)) {
+      const lightingData = createDirectionalLightUniformData(directionalLights);
+      const lightingBuffer = context.device.createBuffer({
+        label: `${node.node.id}:lighting`,
+        size: lightingData.byteLength,
+        usage: uniformUsage | bufferCopyDstUsage,
+      });
+      context.queue.writeBuffer(lightingBuffer, 0, toBufferSource(lightingData));
+      pass.setBindGroup(
+        2,
+        context.device.createBindGroup({
+          layout: pipeline.getBindGroupLayout(2),
+          entries: [{
+            binding: 0,
+            resource: {
+              buffer: lightingBuffer,
+            },
+          }],
+        }),
+      );
     }
 
     if (geometry.indexBuffer && geometry.indexCount > 0) {

--- a/packages/renderer/src/shaders/built_in_forward_lit.wgsl
+++ b/packages/renderer/src/shaders/built_in_forward_lit.wgsl
@@ -1,0 +1,48 @@
+struct MeshTransform {
+  world: mat4x4<f32>,
+  normal: mat4x4<f32>,
+};
+
+struct MaterialUniforms {
+  values: array<vec4<f32>, 16>,
+};
+
+struct LightingUniforms {
+  directions: array<vec4<f32>, 4>,
+  colors: array<vec4<f32>, 4>,
+  settings: vec4<f32>,
+};
+
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) worldNormal: vec3<f32>,
+};
+
+@group(0) @binding(0) var<uniform> meshTransform: MeshTransform;
+@group(1) @binding(0) var<uniform> material: MaterialUniforms;
+@group(2) @binding(0) var<uniform> lighting: LightingUniforms;
+
+@vertex
+fn vsMain(@location(0) position: vec3<f32>, @location(1) normal: vec3<f32>) -> VsOut {
+  var out: VsOut;
+  out.position = meshTransform.world * vec4<f32>(position, 1.0);
+  out.worldNormal = normalize((meshTransform.normal * vec4<f32>(normal, 0.0)).xyz);
+  return out;
+}
+
+@fragment
+fn fsMain(in: VsOut) -> @location(0) vec4<f32> {
+  let lightCount = i32(lighting.settings.x);
+  let ambient = lighting.settings.y;
+  let baseColor = material.values[0];
+  let surfaceNormal = normalize(in.worldNormal);
+  var litColor = baseColor.rgb * ambient;
+
+  for (var index = 0; index < lightCount; index += 1) {
+    let lightDirection = normalize(-lighting.directions[index].xyz);
+    let diffuse = max(dot(surfaceNormal, lightDirection), 0.0);
+    litColor += baseColor.rgb * lighting.colors[index].xyz * lighting.colors[index].w * diffuse;
+  }
+
+  return vec4<f32>(litColor, baseColor.a);
+}

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -1,7 +1,14 @@
 import { assertAlmostEquals, assertEquals, assertStrictEquals } from 'jsr:@std/assert@^1.0.14';
 import { evaluateScene } from '@rieul3d/core';
 import { createOffscreenContext, createRuntimeResidency } from '@rieul3d/gpu';
-import { appendMaterial, appendMesh, appendNode, createNode, createSceneIr } from '@rieul3d/ir';
+import {
+  appendLight,
+  appendMaterial,
+  appendMesh,
+  appendNode,
+  createNode,
+  createSceneIr,
+} from '@rieul3d/ir';
 import {
   createMaterialRegistry,
   ensureBuiltInForwardPipeline,
@@ -632,6 +639,15 @@ fn fsMain() -> @location(0) vec4<f32> {
 
   assertEquals(resolveMaterialProgram(registry).id, 'built-in:unlit');
   assertEquals(
+    resolveMaterialProgram(registry, {
+      id: 'material-lit',
+      kind: 'lit',
+      textures: [],
+      parameters: {},
+    }).id,
+    'built-in:lit',
+  );
+  assertEquals(
     resolveMaterialProgram(
       registry,
       {
@@ -832,6 +848,86 @@ Deno.test('renderForwardFrame binds base-color textures for textured built-in un
     mocks.passActions.filter((action) => action.type === 'setVertexBuffer').length,
     2,
   );
+});
+
+Deno.test('renderForwardFrame binds lighting uniforms for built-in lit materials', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendLight(scene, {
+    id: 'light-directional',
+    kind: 'directional',
+    color: { x: 1, y: 0.95, z: 0.9 },
+    intensity: 1.5,
+  });
+  scene = appendMaterial(scene, {
+    id: 'material-lit',
+    kind: 'lit',
+    textures: [],
+    parameters: {
+      color: { x: 0.7, y: 0.5, z: 0.3, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-lit',
+    materialId: 'material-lit',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('light-node', { lightId: 'light-directional' }));
+  scene = appendNode(scene, createNode('mesh-lit-node', { meshId: 'mesh-lit' }));
+
+  runtimeResidency.geometry.set('mesh-lit', {
+    meshId: 'mesh-lit',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      NORMAL: { id: 1 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+
+  const binding = createOffscreenContext({
+    device: mocks.device as unknown as GPUDevice,
+    target: createHeadlessTarget(64, 64),
+  });
+
+  const result = renderForwardFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    binding,
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(result.drawCount, 1);
+  assertEquals(mocks.bindGroupEntries.length, 3);
+  assertEquals(mocks.bindGroupEntries[0].map((entry) => entry.binding), [0]);
+  assertEquals(mocks.bindGroupEntries[1].map((entry) => entry.binding), [0]);
+  assertEquals(mocks.bindGroupEntries[2].map((entry) => entry.binding), [0]);
+  const litVertexBuffers = mocks.pipelines[0].descriptor.vertex?.buffers ?? [];
+  assertEquals(litVertexBuffers.length, 2);
+  assertEquals(
+    litVertexBuffers.map((buffer) => buffer?.arrayStride ?? 0),
+    [12, 12],
+  );
+  const litTransformWrite = mocks.writeBufferCalls.find((call) => call.bytes.byteLength === 128);
+  const lightingWrite = mocks.writeBufferCalls.find((call) => call.bytes.byteLength === 144);
+  assertEquals(Boolean(litTransformWrite), true);
+  assertEquals(
+    Array.from(new Float32Array(lightingWrite?.bytes.buffer.slice(0, 16) ?? new ArrayBuffer(0))),
+    [0, 0, -1, 0],
+  );
+  const lightingColor = Array.from(
+    new Float32Array(
+      lightingWrite?.bytes.buffer.slice(64, 80) ?? new ArrayBuffer(0),
+    ),
+  );
+  assertAlmostEquals(lightingColor[0], 1, 1e-6);
+  assertAlmostEquals(lightingColor[1], 0.95, 1e-6);
+  assertAlmostEquals(lightingColor[2], 0.9, 1e-6);
+  assertAlmostEquals(lightingColor[3], 1.5, 1e-6);
 });
 
 Deno.test('renderForwardFrame does not append texture bindings for shader-selected unlit programs', () => {

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -1,13 +1,21 @@
 import { assertAlmostEquals, assertEquals, assertThrows } from 'jsr:@std/assert@^1.0.14';
 import { evaluateScene } from '@rieul3d/core';
 import { createRuntimeResidency } from '@rieul3d/gpu';
-import { appendMaterial, appendMesh, appendNode, createNode, createSceneIr } from '@rieul3d/ir';
+import {
+  appendLight,
+  appendMaterial,
+  appendMesh,
+  appendNode,
+  createNode,
+  createSceneIr,
+} from '@rieul3d/ir';
 import {
   assertRendererSceneCapabilities,
   collectRendererCapabilityIssues,
   createDeferredRenderer,
   createForwardRenderer,
   createMaterialRegistry,
+  extractDirectionalLightItems,
   extractSdfPassItems,
   extractVolumePassItems,
   type MaterialProgram,
@@ -245,6 +253,27 @@ Deno.test('extractSdfPassItems returns supported sphere and box sdf nodes with d
   assertAlmostEquals(items[1].worldToLocalRotation[8], 1, 1e-6);
 });
 
+Deno.test('extractDirectionalLightItems resolves world-space directions from light nodes', () => {
+  let scene = createSceneIr('scene');
+  scene = appendLight(scene, {
+    id: 'light-directional',
+    kind: 'directional',
+    color: { x: 1, y: 0.9, z: 0.8 },
+    intensity: 2,
+  });
+  scene = appendNode(scene, createNode('light-node', { lightId: 'light-directional' }));
+
+  const items = extractDirectionalLightItems(evaluateScene(scene, { timeMs: 0 }));
+
+  assertEquals(items, [{
+    nodeId: 'light-node',
+    lightId: 'light-directional',
+    direction: [0, 0, -1],
+    color: [1, 0.9, 0.8],
+    intensity: 2,
+  }]);
+});
+
 Deno.test('collectRendererCapabilityIssues accepts the current forward primitive mix', () => {
   const materialRegistry = createMaterialRegistry();
   registerWgslMaterial(materialRegistry, createFlatRedProgram());
@@ -282,6 +311,94 @@ Deno.test('collectRendererCapabilityIssues accepts the current forward primitive
   );
 
   assertEquals(issues, []);
+});
+
+Deno.test('collectRendererCapabilityIssues accepts lit materials when a directional light is present', () => {
+  let scene = createSceneIr('scene');
+  scene = appendLight(scene, {
+    id: 'light-directional',
+    kind: 'directional',
+    color: { x: 1, y: 1, z: 1 },
+    intensity: 1,
+  });
+  scene = appendMaterial(scene, {
+    id: 'material-lit',
+    kind: 'lit',
+    textures: [],
+    parameters: {
+      color: { x: 0.8, y: 0.4, z: 0.2, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-lit',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('light-node', { lightId: 'light-directional' }));
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+
+  const issues = collectRendererCapabilityIssues(
+    createForwardRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(issues, []);
+});
+
+Deno.test('collectRendererCapabilityIssues rejects lit materials without lights or normals', () => {
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-lit',
+    kind: 'lit',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {
+      color: { x: 0.6, y: 0.7, z: 0.9, w: 1 },
+    },
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-lit',
+    attributes: [{ semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] }],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+
+  const issues = collectRendererCapabilityIssues(
+    createForwardRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(issues, [
+    {
+      nodeId: 'mesh-node',
+      feature: 'light',
+      requirement: 'light-source:directional',
+      message:
+        'renderer "forward" requires at least one directional light for material "material-lit"',
+    },
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'light-material:textures-unsupported',
+      message:
+        'renderer "forward" does not yet support textures on built-in lit material "material-lit"',
+    },
+    {
+      nodeId: 'mesh-node',
+      feature: 'material-binding',
+      requirement: 'vertex-attribute:NORMAL',
+      message:
+        'renderer "forward" cannot light node "mesh-node" because mesh "mesh-0" is missing NORMAL',
+    },
+  ]);
 });
 
 Deno.test('collectRendererCapabilityIssues accepts supported box sdf ops for execution', () => {


### PR DESCRIPTION
## Summary\n- add first-class Scene IR light definitions plus node light bindings and evaluated directional light extraction\n- add a built-in forward Lambert lit material path with capability preflight, uniforms, and shader support\n- refresh the browser forward example, docs, and renderer tests around scene lighting\n\n## Testing\n- deno task check\n- deno task docs:check\n- deno task example:browser:build\n\nCloses #68