### PR TITLE
Add deferred custom WGSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Implemented today:
 - BDL-driven `SceneIr` generation with drift checks in CI
 - camera declarations in Scene IR plus evaluated active-camera view/projection support
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
-- forward rendering, minimal deferred mesh/unlit execution with optional baseColor texture sampling,
-  first-class directional light nodes with built-in forward Lambert shading, first SDF raymarch
-  execution, and headless snapshot readback
+- forward rendering, minimal deferred mesh execution with built-in unlit plus custom WGSL G-buffer
+  paths, optional baseColor texture sampling, first-class directional light nodes with built-in
+  forward Lambert shading, first SDF raymarch execution, and headless snapshot readback
 - forward SDF sphere and box raymarch execution with capability preflight alignment
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
   sampling, material parameter uploads, custom WGSL registration, declared material texture

--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -104,7 +104,7 @@ The deferred renderer declares:
 - `volume: unsupported`
 - `light: unsupported`
 - `builtInMaterialKinds: ['unlit']`
-- `customShaders: unsupported`
+- `customShaders: supported`
 
 This now matches the implemented minimal deferred path:
 
@@ -113,8 +113,10 @@ This now matches the implemented minimal deferred path:
   fullscreen lighting pass
 - built-in `unlit` materials may also sample resident `baseColor` textures when meshes provide
   `TEXCOORD_0`
-- SDF, volume, and custom WGSL materials remain outside the deferred execution surface and fail
-  preflight with explicit diagnostics
+- registered custom WGSL materials may also execute in the G-buffer pass when they provide
+  compatible transform bindings, fragment outputs, and declared material bindings
+- SDF and volume primitives remain outside the deferred execution surface and fail preflight with
+  explicit diagnostics
 
 ## Relationship To Other Specs
 

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -38,7 +38,8 @@ The initial renderer uses a lightweight pass graph:
 - Forward rendering now also consumes first-class directional light nodes for built-in Lambert mesh
   shading.
 - Deferred rendering now executes a minimal mesh-only path with a depth prepass, an unlit
-  albedo/normal G-buffer pass, and a fullscreen lighting resolve.
+  albedo/normal G-buffer pass, registered custom WGSL G-buffer programs, and a fullscreen lighting
+  resolve.
 - Forward rendering also encodes a dedicated SDF raymarch pass for supported sphere and box
   primitives.
 - Forward rendering also encodes a first volume raymarch pass for volume primitives with residency.
@@ -55,6 +56,8 @@ The initial renderer uses a lightweight pass graph:
   at least one directional light.
 - Built-in deferred unlit shading supports the same optional base-color texture sampling when
   `NORMAL` and `TEXCOORD_0` data plus texture residency are available.
+- Deferred custom WGSL programs may also target the G-buffer path when they write the same two
+  render targets and match the deferred transform/material binding contract.
 - Built-in forward lit mesh draws also upload an inverse-transpose normal matrix plus a compact
   directional-light uniform block.
 - Material parameter uploads and bind group creation are implemented for built-in unlit shading.
@@ -91,6 +94,9 @@ The initial renderer uses a lightweight pass graph:
   `@group(1) @binding(1)` and `@group(1) @binding(2)`.
 - Built-in deferred textured unlit shading uses the same `@group(1)` base-color texture/sampler
   contract during G-buffer writes.
+- Deferred custom WGSL programs that register with `usesTransformBindings: true` should match the
+  deferred `@group(0)` transform contract: evaluated node world matrix plus inverse-transpose normal
+  matrix.
 - Custom WGSL programs that want the same evaluated mesh transform upload should register with
   `usesTransformBindings: true` and match the same `@group(0)` transform contract.
 - Custom WGSL programs that need sampled textures should declare matching texture/sampler bindings
@@ -108,7 +114,7 @@ The initial renderer uses a lightweight pass graph:
 
 ## Known Gaps
 
-- Deferred rendering does not yet cover custom WGSL materials, SDF primitives, or volume primitives.
+- Deferred rendering does not yet cover SDF primitives or volume primitives.
 - Deferred rendering does not yet consume Scene IR light nodes or built-in lit materials.
 - SDF execution currently supports sphere and box primitives only; broader graph/operator coverage
   is still pending.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -676,7 +676,7 @@ export const createDeferredRenderer = (label = 'deferred'): Renderer => ({
     volume: 'unsupported',
     light: 'unsupported',
     builtInMaterialKinds: ['unlit'],
-    customShaders: 'unsupported',
+    customShaders: 'supported',
   },
   passes: [
     { id: 'depth-prepass', kind: 'depth-prepass', reads: ['scene'], writes: ['depth'] },
@@ -1627,6 +1627,22 @@ const createDefaultMaterial = (): Material => ({
   },
 });
 
+const resolveDeferredGbufferProgram = (
+  materialRegistry: MaterialRegistry,
+  material: Material,
+  geometry: NonNullable<RuntimeResidency['geometry'] extends Map<string, infer T> ? T : never>,
+  residency: RuntimeResidency,
+): MaterialProgram => {
+  if (material.shaderId) {
+    return resolveMaterialProgram(materialRegistry, material);
+  }
+
+  const baseColorTexture = getBaseColorTextureResidency(residency, material);
+  return baseColorTexture && geometry.attributeBuffers.TEXCOORD_0
+    ? builtInDeferredGbufferTexturedUnlitProgram
+    : builtInDeferredGbufferUnlitProgram;
+};
+
 export const renderForwardFrame = (
   context: GpuRenderExecutionContext,
   binding: RenderContextBinding,
@@ -1951,10 +1967,12 @@ export const renderDeferredFrame = (
     }
 
     const material = node.material ?? createDefaultMaterial();
-    const baseColorTexture = getBaseColorTextureResidency(residency, material);
-    const gbufferProgram = baseColorTexture && geometry.attributeBuffers.TEXCOORD_0
-      ? builtInDeferredGbufferTexturedUnlitProgram
-      : builtInDeferredGbufferUnlitProgram;
+    const gbufferProgram = resolveDeferredGbufferProgram(
+      materialRegistry,
+      material,
+      geometry,
+      residency,
+    );
     const gbufferPipeline = ensureDeferredGbufferPipeline(
       context,
       residency,

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -43,6 +43,92 @@ type MockPassAction =
   | Readonly<{ type: 'drawIndexed'; indexCount: number }>
   | Readonly<{ type: 'end' }>;
 
+const createDeferredTexturedCustomProgram = () => ({
+  id: 'shader:deferred-textured-custom',
+  label: 'Deferred Textured Custom',
+  wgsl: `
+// Deferred Textured Custom
+struct MeshTransform {
+  world: mat4x4<f32>,
+  normal: mat4x4<f32>,
+};
+
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) normal: vec3<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+struct FsOut {
+  @location(0) albedo: vec4<f32>,
+  @location(1) encodedNormal: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> meshTransform: MeshTransform;
+@group(1) @binding(0) var customTexture: texture_2d<f32>;
+@group(1) @binding(1) var customSampler: sampler;
+
+@vertex
+fn vsMain(
+  @location(0) position: vec3<f32>,
+  @location(1) normal: vec3<f32>,
+  @location(2) uv: vec2<f32>,
+) -> VsOut {
+  var out: VsOut;
+  out.position = meshTransform.world * vec4<f32>(position, 1.0);
+  out.normal = normalize((meshTransform.normal * vec4<f32>(normal, 0.0)).xyz);
+  out.uv = uv;
+  return out;
+}
+
+@fragment
+fn fsMain(in: VsOut) -> FsOut {
+  var out: FsOut;
+  out.albedo = textureSample(customTexture, customSampler, in.uv);
+  out.encodedNormal = vec4<f32>((normalize(in.normal) * 0.5) + vec3<f32>(0.5), 1.0);
+  return out;
+}
+`,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  vertexAttributes: [
+    {
+      semantic: 'POSITION',
+      shaderLocation: 0,
+      format: 'float32x3' as const,
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'NORMAL',
+      shaderLocation: 1,
+      format: 'float32x3' as const,
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'TEXCOORD_0',
+      shaderLocation: 2,
+      format: 'float32x2' as const,
+      offset: 0,
+      arrayStride: 8,
+    },
+  ],
+  usesTransformBindings: true,
+  materialBindings: [
+    {
+      kind: 'texture' as const,
+      binding: 0,
+      textureSemantic: 'baseColor',
+    },
+    {
+      kind: 'sampler' as const,
+      binding: 1,
+      textureSemantic: 'baseColor',
+    },
+  ],
+});
+
 const createRenderMocks = () => {
   const pipelines: MockPipeline[] = [];
   const shaders: MockShader[] = [];
@@ -514,6 +600,82 @@ Deno.test('renderDeferredFrame binds base-color textures for textured deferred u
   );
   assertEquals(mocks.bindGroupEntries.length, 4);
   assertEquals(mocks.bindGroupEntries[2].map((entry) => entry.binding), [0, 1, 2]);
+});
+
+Deno.test('renderDeferredFrame uses registered custom WGSL gbuffer programs', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  const registry = createMaterialRegistry();
+  registerWgslMaterial(registry, createDeferredTexturedCustomProgram());
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-custom',
+    kind: 'custom',
+    shaderId: 'shader:deferred-textured-custom',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {},
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-custom-deferred',
+    materialId: 'material-custom',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('node-custom-deferred', { meshId: 'mesh-custom-deferred' }));
+
+  runtimeResidency.geometry.set('mesh-custom-deferred', {
+    meshId: 'mesh-custom-deferred',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      NORMAL: { id: 1 } as unknown as GPUBuffer,
+      TEXCOORD_0: { id: 2 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  runtimeResidency.textures.set('texture-0', {
+    textureId: 'texture-0',
+    texture: { id: 0 } as unknown as GPUTexture,
+    view: { id: 1 } as unknown as GPUTextureView,
+    sampler: { id: 2 } as unknown as GPUSampler,
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm',
+  });
+
+  const binding = createOffscreenContext({
+    device: mocks.device as unknown as GPUDevice,
+    target: createHeadlessTarget(64, 64),
+  });
+
+  const result = renderDeferredFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    binding,
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+    registry,
+  );
+
+  assertEquals(result.drawCount, 3);
+  assertEquals(
+    mocks.shaders.some((shader) => shader.code.includes('Deferred Textured Custom')),
+    true,
+  );
+  const deferredGbufferPipeline = mocks.pipelines.find((pipeline) =>
+    pipeline.descriptor.fragment?.targets?.length === 2 &&
+    (pipeline.descriptor.vertex?.buffers?.length ?? 0) === 3
+  );
+  assertEquals(deferredGbufferPipeline?.descriptor.fragment?.targets?.length, 2);
+  assertEquals(mocks.bindGroupEntries[2].map((entry) => entry.binding), [0, 1]);
 });
 
 Deno.test('renderForwardFrame encodes a dedicated sdf raymarch pass for supported sphere and box nodes', () => {

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -106,6 +106,91 @@ fn fsMain() -> @location(0) vec4<f32> {
   ],
 });
 
+const createDeferredTexturedCustomProgram = (): MaterialProgram => ({
+  id: 'shader:deferred-textured-custom',
+  label: 'Deferred Textured Custom',
+  wgsl: `
+struct MeshTransform {
+  world: mat4x4<f32>,
+  normal: mat4x4<f32>,
+};
+
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) normal: vec3<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+struct FsOut {
+  @location(0) albedo: vec4<f32>,
+  @location(1) encodedNormal: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> meshTransform: MeshTransform;
+@group(1) @binding(0) var customTexture: texture_2d<f32>;
+@group(1) @binding(1) var customSampler: sampler;
+
+@vertex
+fn vsMain(
+  @location(0) position: vec3<f32>,
+  @location(1) normal: vec3<f32>,
+  @location(2) uv: vec2<f32>,
+) -> VsOut {
+  var out: VsOut;
+  out.position = meshTransform.world * vec4<f32>(position, 1.0);
+  out.normal = normalize((meshTransform.normal * vec4<f32>(normal, 0.0)).xyz);
+  out.uv = uv;
+  return out;
+}
+
+@fragment
+fn fsMain(in: VsOut) -> FsOut {
+  var out: FsOut;
+  out.albedo = textureSample(customTexture, customSampler, in.uv);
+  out.encodedNormal = vec4<f32>((normalize(in.normal) * 0.5) + vec3<f32>(0.5), 1.0);
+  return out;
+}
+`,
+  vertexEntryPoint: 'vsMain',
+  fragmentEntryPoint: 'fsMain',
+  vertexAttributes: [
+    {
+      semantic: 'POSITION',
+      shaderLocation: 0,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'NORMAL',
+      shaderLocation: 1,
+      format: 'float32x3',
+      offset: 0,
+      arrayStride: 12,
+    },
+    {
+      semantic: 'TEXCOORD_0',
+      shaderLocation: 2,
+      format: 'float32x2',
+      offset: 0,
+      arrayStride: 8,
+    },
+  ],
+  usesTransformBindings: true,
+  materialBindings: [
+    {
+      kind: 'texture' as const,
+      binding: 0,
+      textureSemantic: 'baseColor',
+    },
+    {
+      kind: 'sampler' as const,
+      binding: 1,
+      textureSemantic: 'baseColor',
+    },
+  ],
+});
+
 Deno.test('forward renderer omits raymarch pass when scene has no sdf or volume nodes', () => {
   let scene = createSceneIr('scene');
   scene = appendNode(scene, createNode('node-0'));
@@ -663,6 +748,54 @@ Deno.test('deferred renderer accepts textured unlit scenes with normals, uvs, an
     createDeferredRenderer(),
     evaluateScene(scene, { timeMs: 0 }),
     createMaterialRegistry(),
+    residency,
+  );
+
+  assertEquals(issues, []);
+});
+
+Deno.test('deferred renderer accepts custom WGSL materials that satisfy deferred gbuffer bindings', () => {
+  const materialRegistry = createMaterialRegistry();
+  const residency = createRuntimeResidency();
+  registerWgslMaterial(materialRegistry, createDeferredTexturedCustomProgram());
+  let scene = createSceneIr('scene');
+  scene = appendMaterial(scene, {
+    id: 'material-custom',
+    kind: 'custom',
+    shaderId: 'shader:deferred-textured-custom',
+    textures: [{
+      id: 'texture-0',
+      assetId: 'image-0',
+      semantic: 'baseColor',
+      colorSpace: 'srgb',
+      sampler: 'linear-repeat',
+    }],
+    parameters: {},
+  });
+  scene = appendMesh(scene, {
+    id: 'mesh-0',
+    materialId: 'material-custom',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+      { semantic: 'TEXCOORD_0', itemSize: 2, values: [0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-0' }));
+  residency.textures.set('texture-0', {
+    textureId: 'texture-0',
+    texture: {} as GPUTexture,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm',
+  });
+
+  const issues = collectRendererCapabilityIssues(
+    createDeferredRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+    materialRegistry,
     residency,
   );
 


### PR DESCRIPTION
## Summary
- allow deferred renderer preflight and execution to use registered custom WGSL G-buffer programs
- keep built-in deferred textured unlit fallback while routing shader-backed materials through their declared bindings
- refresh renderer docs and add deferred custom-program coverage in renderer/forward tests

## Testing
- deno test --unstable-raw-imports tests/renderer_test.ts tests/forward_render_test.ts
- deno task docs:check
- deno task check

Refs #66