### PR TITLE
Compose deferred raymarch passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Implemented today:
 - camera declarations in Scene IR plus evaluated active-camera view/projection support
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
 - forward rendering, minimal deferred mesh execution with built-in unlit plus custom WGSL G-buffer
-  paths, optional baseColor texture sampling, first-class directional light nodes with built-in
-  forward Lambert shading, first SDF raymarch execution, and headless snapshot readback
+  paths, optional baseColor texture sampling, post-lighting deferred SDF/volume composition,
+  first-class directional light nodes with built-in forward Lambert shading, first SDF raymarch
+  execution, and headless snapshot readback
 - forward SDF sphere and box raymarch execution with capability preflight alignment
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
   sampling, material parameter uploads, custom WGSL registration, declared material texture

--- a/docs/specs/renderer-capabilities.md
+++ b/docs/specs/renderer-capabilities.md
@@ -100,8 +100,8 @@ volume raymarch passes are encoded in the forward renderer.
 The deferred renderer declares:
 
 - `mesh: supported`
-- `sdf: unsupported`
-- `volume: unsupported`
+- `sdf: supported`
+- `volume: supported`
 - `light: unsupported`
 - `builtInMaterialKinds: ['unlit']`
 - `customShaders: supported`
@@ -115,8 +115,10 @@ This now matches the implemented minimal deferred path:
   `TEXCOORD_0`
 - registered custom WGSL materials may also execute in the G-buffer pass when they provide
   compatible transform bindings, fragment outputs, and declared material bindings
-- SDF and volume primitives remain outside the deferred execution surface and fail preflight with
-  explicit diagnostics
+- SDF sphere/box primitives and resident volumes are composited afterward through the existing
+  raymarch passes, so deferred frames can execute hybrid mesh-plus-raymarch scenes
+- scene lights and built-in `lit` materials still remain outside the deferred execution surface and
+  fail preflight with explicit diagnostics
 
 ## Relationship To Other Specs
 

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -38,8 +38,8 @@ The initial renderer uses a lightweight pass graph:
 - Forward rendering now also consumes first-class directional light nodes for built-in Lambert mesh
   shading.
 - Deferred rendering now executes a minimal mesh-only path with a depth prepass, an unlit
-  albedo/normal G-buffer pass, registered custom WGSL G-buffer programs, and a fullscreen lighting
-  resolve.
+  albedo/normal G-buffer pass, registered custom WGSL G-buffer programs, a fullscreen lighting
+  resolve, and post-lighting SDF/volume raymarch composition.
 - Forward rendering also encodes a dedicated SDF raymarch pass for supported sphere and box
   primitives.
 - Forward rendering also encodes a first volume raymarch pass for volume primitives with residency.
@@ -58,6 +58,9 @@ The initial renderer uses a lightweight pass graph:
   `NORMAL` and `TEXCOORD_0` data plus texture residency are available.
 - Deferred custom WGSL programs may also target the G-buffer path when they write the same two
   render targets and match the deferred transform/material binding contract.
+- Deferred frames now reuse the existing SDF sphere/box and volume raymarch passes after lighting,
+  so hybrid scenes can keep mesh shading in deferred while compositing raymarched primitives into
+  the same output target.
 - Built-in forward lit mesh draws also upload an inverse-transpose normal matrix plus a compact
   directional-light uniform block.
 - Material parameter uploads and bind group creation are implemented for built-in unlit shading.
@@ -114,7 +117,6 @@ The initial renderer uses a lightweight pass graph:
 
 ## Known Gaps
 
-- Deferred rendering does not yet cover SDF primitives or volume primitives.
 - Deferred rendering does not yet consume Scene IR light nodes or built-in lit materials.
 - SDF execution currently supports sphere and box primitives only; broader graph/operator coverage
   is still pending.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -672,8 +672,8 @@ export const createDeferredRenderer = (label = 'deferred'): Renderer => ({
   label,
   capabilities: {
     mesh: 'supported',
-    sdf: 'unsupported',
-    volume: 'unsupported',
+    sdf: 'supported',
+    volume: 'supported',
     light: 'unsupported',
     builtInMaterialKinds: ['unlit'],
     customShaders: 'supported',
@@ -682,6 +682,7 @@ export const createDeferredRenderer = (label = 'deferred'): Renderer => ({
     { id: 'depth-prepass', kind: 'depth-prepass', reads: ['scene'], writes: ['depth'] },
     { id: 'gbuffer', kind: 'gbuffer', reads: ['scene', 'depth'], writes: ['gbuffer'] },
     { id: 'lighting', kind: 'lighting', reads: ['gbuffer', 'depth'], writes: ['color'] },
+    { id: 'raymarch', kind: 'raymarch', reads: ['scene', 'color'], writes: ['color'] },
     { id: 'present', kind: 'present', reads: ['color'], writes: ['target'] },
   ],
 });
@@ -2088,6 +2089,9 @@ export const renderDeferredFrame = (
   lightingPass.draw(3, 1, 0, 0);
   lightingPass.end();
   drawCount += 1;
+
+  drawCount += renderSdfRaymarchPass(context, encoder, binding, residency, evaluatedScene);
+  drawCount += renderVolumeRaymarchPass(context, encoder, binding, residency, evaluatedScene);
 
   const commandBuffer = encoder.finish();
   context.queue.submit([commandBuffer]);

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -1496,3 +1496,76 @@ Deno.test('renderForwardFrame uploads parented mesh transforms after scene evalu
   assertAlmostEquals(uploadedMatrix[28] ?? 0, 0, 1e-5);
   assertAlmostEquals(uploadedMatrix[31] ?? 0, 1, 1e-5);
 });
+
+Deno.test('renderDeferredFrame composites sdf and volume raymarch passes after deferred lighting', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMesh(scene, {
+    id: 'mesh-deferred',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-deferred' }));
+  scene = {
+    ...scene,
+    sdfPrimitives: [{
+      id: 'sdf-0',
+      op: 'sphere',
+      parameters: {
+        radius: { x: 0.5, y: 0, z: 0, w: 0 },
+      },
+    }],
+    volumePrimitives: [{
+      id: 'volume-0',
+      assetId: 'volume-asset-0',
+      dimensions: { x: 4, y: 4, z: 4 },
+      format: 'density:r8unorm',
+    }],
+  };
+  scene = appendNode(scene, createNode('sdf-node', { sdfId: 'sdf-0' }));
+  scene = appendNode(scene, createNode('volume-node', { volumeId: 'volume-0' }));
+
+  runtimeResidency.geometry.set('mesh-deferred', {
+    meshId: 'mesh-deferred',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      NORMAL: { id: 1 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  runtimeResidency.volumes.set('volume-0', {
+    volumeId: 'volume-0',
+    texture: { id: 0 } as unknown as GPUTexture,
+    view: { id: 1 } as unknown as GPUTextureView,
+    sampler: { id: 2 } as unknown as GPUSampler,
+    width: 4,
+    height: 4,
+    depth: 4,
+    format: 'r8unorm',
+  });
+
+  const binding = createOffscreenContext({
+    device: mocks.device as unknown as GPUDevice,
+    target: createHeadlessTarget(64, 64),
+  });
+
+  const result = renderDeferredFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    binding,
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(result.drawCount, 5);
+  assertEquals(result.submittedCommandBufferCount, 1);
+  assertEquals(mocks.renderPassCount.current, 5);
+  assertEquals(mocks.pipelines.length, 5);
+  assertEquals(
+    mocks.passActions.filter((action) => action.type === 'draw').length,
+    5,
+  );
+});

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -228,6 +228,42 @@ Deno.test('deferred renderer plans only the implemented mesh passes', () => {
   ]);
 });
 
+Deno.test('deferred renderer plans a hybrid raymarch pass when sdf or volume nodes are present', () => {
+  let scene = createSceneIr('scene');
+  scene = {
+    ...scene,
+    sdfPrimitives: [{
+      id: 'sdf-0',
+      op: 'sphere',
+      parameters: {
+        radius: { x: 0.5, y: 0, z: 0, w: 0 },
+      },
+    }],
+    volumePrimitives: [{
+      id: 'volume-0',
+      assetId: 'volume-asset-0',
+      dimensions: { x: 4, y: 4, z: 4 },
+      format: 'density:r8unorm',
+    }],
+  };
+  scene = appendNode(scene, createNode('sdf-node', { sdfId: 'sdf-0' }));
+  scene = appendNode(scene, createNode('volume-node', { volumeId: 'volume-0' }));
+
+  const frame = planFrame(
+    createDeferredRenderer(),
+    evaluateScene(scene, { timeMs: 0 }),
+    createRuntimeResidency(),
+  );
+
+  assertEquals(frame.passes.map((pass) => pass.id), [
+    'depth-prepass',
+    'gbuffer',
+    'lighting',
+    'raymarch',
+    'present',
+  ]);
+});
+
 Deno.test('extractVolumePassItems returns only evaluated volumes with residency', () => {
   let scene = createSceneIr('scene');
   scene = {
@@ -497,6 +533,49 @@ Deno.test('collectRendererCapabilityIssues accepts supported box sdf ops for exe
   const issues = collectRendererCapabilityIssues(
     createForwardRenderer(),
     evaluateScene(scene, { timeMs: 0 }),
+  );
+
+  assertEquals(issues, []);
+});
+
+Deno.test('collectRendererCapabilityIssues accepts deferred hybrid sdf and volume scenes', () => {
+  const renderer = createDeferredRenderer();
+  const residency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = {
+    ...scene,
+    sdfPrimitives: [{
+      id: 'sdf-0',
+      op: 'sphere',
+      parameters: {
+        radius: { x: 0.5, y: 0, z: 0, w: 0 },
+      },
+    }],
+    volumePrimitives: [{
+      id: 'volume-0',
+      assetId: 'volume-asset-0',
+      dimensions: { x: 4, y: 4, z: 4 },
+      format: 'density:r8unorm',
+    }],
+  };
+  scene = appendNode(scene, createNode('sdf-node', { sdfId: 'sdf-0' }));
+  scene = appendNode(scene, createNode('volume-node', { volumeId: 'volume-0' }));
+  residency.volumes.set('volume-0', {
+    volumeId: 'volume-0',
+    texture: {} as GPUTexture,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 4,
+    height: 4,
+    depth: 4,
+    format: 'r8unorm',
+  });
+
+  const issues = collectRendererCapabilityIssues(
+    renderer,
+    evaluateScene(scene, { timeMs: 0 }),
+    createMaterialRegistry(),
+    residency,
   );
 
   assertEquals(issues, []);


### PR DESCRIPTION
## Summary
- let deferred frames composite the existing SDF sphere/box and volume raymarch passes after the lighting resolve
- advertise deferred sdf/olume capability support and cover hybrid planning/preflight behavior in tests
- refresh rendering docs/README and split remaining deferred light-material work into issue #75

## Testing
- deno test --unstable-raw-imports tests/renderer_test.ts tests/forward_render_test.ts
- deno task docs:check
- deno task check

## References
- Closes #66
- Refs #75