### PR TITLE
Add combined camera/light JSX aliases

### DIFF
--- a/docs/adr/0005-react-scene-object-aliases.md
+++ b/docs/adr/0005-react-scene-object-aliases.md
@@ -14,7 +14,8 @@ The proposed boundary is:
 - combined aliases stay as authoring sugar over existing Scene IR resources plus node bindings
 - explicit resource ids and explicit node ids remain available as the lower-level escape hatch
 - combined aliases may synthesize a default resource plus its first bound node for common authored
-  scene objects, but they must not narrow the underlying IR semantics around rebinding or multiple
+  scene objects when authors provide node-oriented props or children, but they must not change the
+  existing resource-only meaning or narrow the underlying IR semantics around rebinding or multiple
   node attachments
 - aliases must not hide renderer/runtime ownership or make React the source of truth for live scene
   state

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -11,7 +11,8 @@ React integration is a separate package. It must not become the source of truth 
   `<light>`, `<texture>`, and `<asset>`.
 - The JSX surface may expose React-style aliases such as `<group>`, `<perspectiveCamera>`,
   `<orthographicCamera>`, and `<directionalLight>` when they lower cleanly into the same Scene IR.
-  Camera/light aliases now synthesize both the scene resource and an initial bound node.
+  Camera/light aliases stay resource-only by default and synthesize an initial bound node only when
+  authors provide node intent such as children or node transform/id props.
 - Node-like authoring elements may use transform shorthands such as `position`, `rotation`, and
   `scale`; these fold into the existing Scene IR transform object during lowering.
 - Authored trees are lowered into complete Scene IR or evaluated scene inputs.
@@ -44,10 +45,10 @@ them.
 
 The current camera/light alias surface follows the proposed boundary in
 [`../adr/0005-react-scene-object-aliases.md`](../adr/0005-react-scene-object-aliases.md): combined
-aliases synthesize a default resource plus its first bound node, while explicit `<camera>`,
-`<light>`, and `<node>` authoring stays available for multi-bind scenes. The remaining open question
-is whether broader object composition such as mesh/material authoring should join that same combined
-surface.
+aliases can synthesize a default resource plus its first bound node when authors ask for node
+behavior, while explicit `<camera>`, `<light>`, and `<node>` authoring stays available for
+resource-only and multi-bind scenes. The remaining open question is whether broader object
+composition such as mesh/material authoring should join that same combined surface.
 
 ## Current Status
 

--- a/examples/browser_react_authoring/README.md
+++ b/examples/browser_react_authoring/README.md
@@ -3,7 +3,8 @@
 This example shows the current bridge between `@rieul3d/react` and the existing runtime layers. It
 authors a scene with TSX, including combined scene-object aliases such as `perspectiveCamera` plus
 node transform shorthands such as `position`, lowers that tree into `SceneIr`, then renders the
-result through the browser forward pipeline.
+result through the browser forward pipeline. Resource-only aliases remain available when no node
+binding props or children are supplied.
 
 This is now a real JSX authoring example, but it is still not a live React renderer or reconciler.
 `@rieul3d/react` currently owns authoring and lowering only.

--- a/examples/browser_react_authoring/main.tsx
+++ b/examples/browser_react_authoring/main.tsx
@@ -23,7 +23,6 @@ canvas.height = 480;
 
 const TriangleScene = () => (
   <scene id='react-browser-authoring' activeCameraId='camera-main'>
-    <perspectiveCamera id='camera-main' />
     <material
       id='triangle-material'
       kind='unlit'

--- a/packages/react/src/authoring.ts
+++ b/packages/react/src/authoring.ts
@@ -376,6 +376,18 @@ const createSceneObjectAliasElement = (
   );
 };
 
+const hasSceneObjectAliasNodeIntent = (
+  nodeProps: SceneObjectAliasNodeProps,
+  children: readonly AuthoringElement[],
+): boolean =>
+  children.length > 0 ||
+  nodeProps.nodeId !== undefined ||
+  nodeProps.name !== undefined ||
+  nodeProps.transform !== undefined ||
+  nodeProps.position !== undefined ||
+  nodeProps.rotation !== undefined ||
+  nodeProps.scale !== undefined;
+
 export const jsx = (
   type:
     | keyof AuthoringPropsByType
@@ -443,11 +455,15 @@ export const jsx = (
       scale,
       ...cameraProps
     } = authoringProps as PerspectiveCameraJsxProps;
+    const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
+    if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
+      return createAuthoringElement('camera', id, { ...cameraProps, type: 'perspective' });
+    }
     return createSceneObjectAliasElement(
       'camera',
       id,
       { ...cameraProps, type: 'perspective' },
-      { nodeId, name, transform, position, rotation, scale },
+      aliasNodeProps,
       { cameraId: id },
       children,
       key,
@@ -466,11 +482,15 @@ export const jsx = (
       scale,
       ...cameraProps
     } = authoringProps as OrthographicCameraJsxProps;
+    const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
+    if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
+      return createAuthoringElement('camera', id, { ...cameraProps, type: 'orthographic' });
+    }
     return createSceneObjectAliasElement(
       'camera',
       id,
       { ...cameraProps, type: 'orthographic' },
-      { nodeId, name, transform, position, rotation, scale },
+      aliasNodeProps,
       { cameraId: id },
       children,
       key,
@@ -489,11 +509,15 @@ export const jsx = (
       scale,
       ...lightProps
     } = authoringProps as DirectionalLightJsxProps;
+    const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
+    if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
+      return createAuthoringElement('light', id, { ...lightProps, kind: 'directional' });
+    }
     return createSceneObjectAliasElement(
       'light',
       id,
       { ...lightProps, kind: 'directional' },
-      { nodeId, name, transform, position, rotation, scale },
+      aliasNodeProps,
       { lightId: id },
       children,
       key,

--- a/tests/react_authoring_test.tsx
+++ b/tests/react_authoring_test.tsx
@@ -355,6 +355,40 @@ Deno.test('authoringTreeToSceneIr lowers react-style alias intrinsics', () => {
   });
 });
 
+Deno.test('react-style aliases stay resource-only without node intent', () => {
+  const cameraProps = {
+    type: 'orthographic' as const,
+    yfov: 0.8,
+  };
+  const lightProps = {
+    kind: 'point' as const,
+    color: { x: 1, y: 0.95, z: 0.9 },
+    intensity: 1.5,
+  };
+
+  const scene = authoringTreeToSceneIr(
+    <scene id='jsx-scene' activeCameraId='camera-main'>
+      <perspectiveCamera id='camera-main' {...cameraProps} />
+      <directionalLight id='sun' {...lightProps} />
+    </scene>,
+  );
+
+  assertEquals(scene.cameras[0], {
+    id: 'camera-main',
+    type: 'perspective',
+    yfov: 0.8,
+    znear: 0.1,
+    zfar: 100,
+  });
+  assertEquals(scene.lights[0], {
+    id: 'sun',
+    kind: 'directional',
+    color: { x: 1, y: 0.95, z: 0.9 },
+    intensity: 1.5,
+  });
+  assertEquals(scene.nodes, []);
+});
+
 Deno.test('react-style aliases preserve their fixed resource kinds when props are spread in', () => {
   const cameraProps = {
     type: 'orthographic' as const,
@@ -375,6 +409,5 @@ Deno.test('react-style aliases preserve their fixed resource kinds when props ar
 
   assertEquals(scene.cameras[0]?.type, 'perspective');
   assertEquals(scene.lights[0]?.kind, 'directional');
-  assertEquals(scene.nodes.find((node) => node.id === 'camera-main')?.cameraId, 'camera-main');
-  assertEquals(scene.nodes.find((node) => node.id === 'sun')?.lightId, 'sun');
+  assertEquals(scene.nodes, []);
 });


### PR DESCRIPTION
## Summary
- make perspectiveCamera, orthographicCamera, and directionalLight synthesize both the scene resource and an initial bound node
- allow combined aliases to carry node transform/name props and nested children while keeping explicit <camera>, <light>, and <node> authoring available
- update React authoring docs and the browser example to use the combined camera alias path

## Testing
- deno test --unstable-raw-imports tests/react_authoring_test.tsx
- deno task docs:check
- deno task example:browser:react:build

Closes #82
Refs #64