### PR TITLE
Draft next React scene-root diff ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Implemented today:
 - a browser React authoring example plus scene-root bridge that commits JSX-authored trees into
   `SceneIr` snapshots before rendering, including JSX-authored scene resources such as meshes,
   materials, and cameras
+- proposed ADR/discussion tracking for the next React live-update boundary decision: whether
+  scene-root commits should stay snapshot-only or expose diff/apply metadata
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and
   recovery rebuild renders, including guards against raymarch fixtures collapsing back to clear-only
   output

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ Use this page as the main navigation hub.
   [`adr/0004-react-jsx-authoring.md`](./adr/0004-react-jsx-authoring.md)
 - Review the proposed React scene-root bridge decision:
   [`adr/0006-react-scene-root-bridge.md`](./adr/0006-react-scene-root-bridge.md)
+- Review the next proposed React live-update contract decision:
+  [`adr/0007-react-scene-root-diff-contract.md`](./adr/0007-react-scene-root-diff-contract.md)
 - Run the browser and native examples, including the textured and custom-material browser workflows:
   [`../examples/README.md`](../examples/README.md)
 - Review the React authoring browser example with full-scene TSX lowering and scene-root commits:

--- a/docs/adr/0007-react-scene-root-diff-contract.md
+++ b/docs/adr/0007-react-scene-root-diff-contract.md
@@ -1,0 +1,37 @@
+# ADR 0007: React Scene-Root Diff Contract
+
+## Status
+
+Proposed
+
+## Decision
+
+After the first `createSceneRoot()` bridge landed, the next unresolved question is whether
+`@rieul3d/react` should keep publishing whole-scene `SceneIr` snapshots as its public live-update
+contract or add a first-class diff/apply surface for committed changes.
+
+The proposal to evaluate is:
+
+- keep the current snapshot commit contract as the stable baseline for now
+- decide separately whether a public diff/apply payload is necessary for caller-owned integrations
+- if diff metadata is introduced, keep it data-only and derived from committed scene state, not from
+  renderer-owned or GPU-owned objects
+- leave renderer, residency, and frame execution ownership outside the React package regardless of
+  which commit shape is chosen
+
+This ADR does not yet select snapshot-only or diff/apply as the accepted long-term boundary. It
+captures the next architecture decision that now blocks follow-up implementation work for issue
+`#64`.
+
+Related discussion: `#90`, "ADR 0007: React scene-root diff/apply contract"
+
+## Consequences
+
+- the repository keeps ADR 0006's snapshot bridge as the current implemented path while the next
+  contract decision remains open
+- caller-owned integrations can continue to consume full snapshots immediately without waiting on a
+  finer-grained protocol
+- any future diff/apply contract will need to justify its public surface in terms of real caller
+  pain, not only theoretical efficiency
+- follow-up implementation work should track issue `#89` once discussion `#90` settles the desired
+  contract shape

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,8 @@ supersedes them.
   add combined camera/light-style JSX aliases without changing core ownership
 - [`0006-react-scene-root-bridge.md`](./0006-react-scene-root-bridge.md): React should publish
   committed scene snapshots through a scene-root bridge before it owns a full live reconciler
+- [`0007-react-scene-root-diff-contract.md`](./0007-react-scene-root-diff-contract.md): decide
+  whether React scene-root commits should stay snapshot-only or expose diff/apply data
 
 ## Related References
 

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -57,6 +57,11 @@ into `SceneIr` snapshots and lets caller-owned integrations subscribe to commit 
 moving residency or renderer ownership into the React package. ADR 0006 still remains Proposed until
 discussion `#85` receives a decision.
 
+The next blocker after that first bridge is now captured in
+[`../adr/0007-react-scene-root-diff-contract.md`](../adr/0007-react-scene-root-diff-contract.md):
+should the public live-update contract remain full-scene snapshots for now, or should React expose a
+diff/apply payload for committed changes? That follow-up remains Proposed pending discussion `#90`.
+
 ## Current Status
 
 - The React package currently lowers declarative authoring structures into SceneIr-friendly data.
@@ -76,6 +81,8 @@ discussion `#85` receives a decision.
   not a live React reconciler.
 - The next unresolved architecture question is whether this full-snapshot scene-root bridge should
   remain the long-term boundary or evolve toward a finer-grained diff/apply contract.
+- Issue `#89` now tracks the implementation follow-up once discussion `#90` resolves that contract
+  question.
 - [`../../examples/browser_react_authoring/README.md`](../../examples/browser_react_authoring/README.md)
   shows the reference browser flow: author a tree with `@rieul3d/react` TSX, commit it through
   `createSceneRoot()`, then hand the published scene snapshot to the existing runtime and renderer


### PR DESCRIPTION
## Summary
- add proposed ADR 0007 to capture the next React live-update decision after the first scene-root bridge landed
- update the docs/spec indexes so the new diff/apply-vs-snapshot decision is visible from the main navigation paths
- record the next implementation follow-up in issue #89 while keeping ADR 0006 and ADR 0007 both Proposed pending discussion decisions

## Testing
- deno task docs:check

Refs #64
Refs #89
Refs #90