### PR TITLE
Add scene-root commit summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Implemented today:
   custom lit shader for mesh normals
 - a browser React authoring example plus scene-root bridge that commits JSX-authored trees into
   `SceneIr` snapshots before rendering, including JSX-authored scene resources such as meshes,
-  materials, and cameras, with commit-summary helpers for selective residency invalidation
+  materials, and cameras, with commit-summary helpers for the current runtime-safe residency reset
+  boundary
 - proposed ADR/discussion tracking for the next React live-update boundary decision: whether
   scene-root commits should stay snapshot-only or expose diff/apply metadata
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and

--- a/docs/adr/0007-react-scene-root-diff-contract.md
+++ b/docs/adr/0007-react-scene-root-diff-contract.md
@@ -31,6 +31,9 @@ Related discussion: `#90`, "ADR 0007: React scene-root diff/apply contract"
   contract decision remains open
 - snapshot consumers can now derive added/removed/updated resource IDs from committed scene pairs
   through helper utilities without locking the repository into a first-class diff/apply protocol
+- the current browser integration still treats node/topology changes as residency-reset boundaries
+  through `commitSummaryNeedsResidencyReset()` because residency caches do not prune dead resource
+  usage yet
 - caller-owned integrations can continue to consume full snapshots immediately without waiting on a
   finer-grained protocol
 - any future diff/apply contract will need to justify its public surface in terms of real caller

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -77,9 +77,13 @@ diff/apply payload for committed changes? That follow-up remains Proposed pendin
 - `summarizeSceneRootCommit()` can derive resource-level added/removed/updated/unchanged ID sets
   from snapshot commits so integrations can make selective invalidation decisions without a separate
   public diff/apply contract.
+- `commitSummaryNeedsResidencyReset()` captures the current safe residency-reset boundary for
+  snapshot consumers: resource changes plus node/topology changes still require a full reset until
+  finer-grained residency pruning exists.
 - Integrations that cache GPU residency against scene/resource IDs must invalidate or rebuild that
   residency when a new committed snapshot replaces resource contents under stable IDs; commit
-  summaries now let them scope that rebuild to the resource classes that actually changed.
+  summaries now let them scope that rebuild without missing node-only changes that can remap which
+  stable resources remain live.
 - Rendering, residency preparation, and execution continue to live in the core/gpu/renderer layers.
 - The browser example now demonstrates full-scene JSX authoring plus scene-root snapshot commits,
   not a live React reconciler.
@@ -89,5 +93,6 @@ diff/apply payload for committed changes? That follow-up remains Proposed pendin
   question.
 - [`../../examples/browser_react_authoring/README.md`](../../examples/browser_react_authoring/README.md)
   shows the reference browser flow: author a tree with `@rieul3d/react` TSX, commit it through
-  `createSceneRoot()`, optionally summarize that commit for selective residency invalidation, then
-  hand the published scene snapshot to the existing runtime and renderer layers.
+  `createSceneRoot()`, summarize that commit, apply `commitSummaryNeedsResidencyReset()` for the
+  current runtime-safe invalidation boundary, then hand the published scene snapshot to the existing
+  runtime and renderer layers.

--- a/examples/browser_react_authoring/README.md
+++ b/examples/browser_react_authoring/README.md
@@ -5,9 +5,9 @@ authors a scene with TSX, including combined scene-object aliases such as `persp
 node transform shorthands such as `position`, commits that tree through `createSceneRoot()`, then
 renders the published `SceneIr` snapshot through the browser forward pipeline. Resource-only aliases
 remain available when no node binding props or children are supplied. Because the bridge publishes
-whole-scene snapshots, the example also uses `summarizeSceneRootCommit()` to detect which resource
-classes changed and only resets cached GPU residency when mesh/material/texture/volume inputs
-actually changed before the next frame upload.
+whole-scene snapshots, the example also uses `summarizeSceneRootCommit()` together with
+`commitSummaryNeedsResidencyReset()` so cached GPU residency still resets for resource or node
+topology changes before the next frame upload.
 
 This is now a real JSX authoring example with the first scene-root bridge, but it is still not a
 live React renderer or reconciler. `@rieul3d/react` currently owns authoring, snapshot commits, and

--- a/examples/browser_react_authoring/main.tsx
+++ b/examples/browser_react_authoring/main.tsx
@@ -11,7 +11,11 @@ import {
   requestGpuContext,
 } from '../../packages/gpu/mod.ts';
 import { createBrowserSurfaceTarget } from '../../packages/platform/mod.ts';
-import { createSceneRoot, summarizeSceneRootCommit } from '../../packages/react/mod.ts';
+import {
+  commitSummaryNeedsResidencyReset,
+  createSceneRoot,
+  summarizeSceneRootCommit,
+} from '../../packages/react/mod.ts';
 import { createMaterialRegistry, renderForwardFrame } from '../../packages/renderer/mod.ts';
 
 const canvas = document.querySelector<HTMLCanvasElement>('#app');
@@ -64,24 +68,7 @@ const residency = createRuntimeResidency();
 
 sceneRoot.subscribe((commit) => {
   scene = commit.scene;
-  const summary = summarizeSceneRootCommit(commit);
-  const needsResidencyReset = summary.assets.addedIds.length > 0 ||
-    summary.assets.removedIds.length > 0 ||
-    summary.assets.updatedIds.length > 0 ||
-    summary.textures.addedIds.length > 0 ||
-    summary.textures.removedIds.length > 0 ||
-    summary.textures.updatedIds.length > 0 ||
-    summary.materials.addedIds.length > 0 ||
-    summary.materials.removedIds.length > 0 ||
-    summary.materials.updatedIds.length > 0 ||
-    summary.meshes.addedIds.length > 0 ||
-    summary.meshes.removedIds.length > 0 ||
-    summary.meshes.updatedIds.length > 0 ||
-    summary.volumePrimitives.addedIds.length > 0 ||
-    summary.volumePrimitives.removedIds.length > 0 ||
-    summary.volumePrimitives.updatedIds.length > 0;
-
-  if (needsResidencyReset) {
+  if (commitSummaryNeedsResidencyReset(summarizeSceneRootCommit(commit))) {
     invalidateResidency(residency);
   }
 });

--- a/packages/react/src/scene_root.ts
+++ b/packages/react/src/scene_root.ts
@@ -42,14 +42,102 @@ export type SceneRoot = Readonly<{
   subscribe: (subscriber: SceneRootSubscriber) => () => void;
 }>;
 
+const HASH_OFFSET = 2166136261;
+const HASH_PRIME = 16777619;
+const numberHashBuffer = new ArrayBuffer(8);
+const numberHashView = new DataView(numberHashBuffer);
+const fingerprintCache = new WeakMap<object, number>();
+
+const mixHash = (hash: number, byte: number): number => {
+  return Math.imul(hash ^ byte, HASH_PRIME) >>> 0;
+};
+
+const hashString = (hash: number, value: string): number => {
+  let nextHash = hash;
+  for (let index = 0; index < value.length; index += 1) {
+    nextHash = mixHash(nextHash, value.charCodeAt(index) & 0xff);
+    nextHash = mixHash(nextHash, value.charCodeAt(index) >>> 8);
+  }
+  return nextHash;
+};
+
+const hashNumber = (hash: number, value: number): number => {
+  numberHashView.setFloat64(0, value, true);
+  let nextHash = hash;
+  for (let index = 0; index < 8; index += 1) {
+    nextHash = mixHash(nextHash, numberHashView.getUint8(index));
+  }
+  return nextHash;
+};
+
+const fingerprintValue = (value: unknown): number => {
+  if (value === null) {
+    return hashString(HASH_OFFSET, 'null');
+  }
+  if (value === undefined) {
+    return hashString(HASH_OFFSET, 'undefined');
+  }
+  if (typeof value === 'string') {
+    return hashString(HASH_OFFSET, value);
+  }
+  if (typeof value === 'number') {
+    return hashNumber(HASH_OFFSET, value);
+  }
+  if (typeof value === 'boolean') {
+    return hashString(HASH_OFFSET, value ? 'true' : 'false');
+  }
+  if (Array.isArray(value)) {
+    let hash = hashString(HASH_OFFSET, 'array');
+    for (const item of value) {
+      const itemFingerprint = fingerprintValue(item);
+      hash = mixHash(hash, 0xff);
+      hash = mixHash(hash, itemFingerprint & 0xff);
+      hash = mixHash(hash, (itemFingerprint >>> 8) & 0xff);
+      hash = mixHash(hash, (itemFingerprint >>> 16) & 0xff);
+      hash = mixHash(hash, itemFingerprint >>> 24);
+    }
+    return hash;
+  }
+  if (typeof value === 'object') {
+    const cachedFingerprint = fingerprintCache.get(value);
+    if (cachedFingerprint !== undefined) {
+      return cachedFingerprint;
+    }
+
+    let hash = hashString(HASH_OFFSET, 'object');
+    const entries = Object.entries(value).sort(([leftKey], [rightKey]) =>
+      leftKey.localeCompare(rightKey)
+    );
+    for (const [key, entryValue] of entries) {
+      hash = hashString(hash, key);
+      const entryFingerprint = fingerprintValue(entryValue);
+      hash = mixHash(hash, entryFingerprint & 0xff);
+      hash = mixHash(hash, (entryFingerprint >>> 8) & 0xff);
+      hash = mixHash(hash, (entryFingerprint >>> 16) & 0xff);
+      hash = mixHash(hash, entryFingerprint >>> 24);
+    }
+
+    fingerprintCache.set(value, hash);
+    return hash;
+  }
+
+  return hashString(HASH_OFFSET, String(value));
+};
+
+const collectionHasChanges = (summary: SceneRootCollectionSummary): boolean => {
+  return summary.addedIds.length > 0 ||
+    summary.removedIds.length > 0 ||
+    summary.updatedIds.length > 0;
+};
+
 const compareSceneRootCollection = <TEntry extends SceneRootEntityWithId>(
   currentEntries: readonly TEntry[],
   previousEntries: readonly TEntry[] | undefined,
 ): SceneRootCollectionSummary => {
   const previousById = new Map(
-    (previousEntries ?? []).map((entry) => [entry.id, JSON.stringify(entry)]),
+    (previousEntries ?? []).map((entry) => [entry.id, fingerprintValue(entry)]),
   );
-  const currentById = new Map(currentEntries.map((entry) => [entry.id, JSON.stringify(entry)]));
+  const currentById = new Map(currentEntries.map((entry) => [entry.id, fingerprintValue(entry)]));
 
   const addedIds: string[] = [];
   const updatedIds: string[] = [];
@@ -83,8 +171,8 @@ const compareSceneRootCollection = <TEntry extends SceneRootEntityWithId>(
 export const summarizeSceneRootCommit = (commit: SceneRootCommit): SceneRootCommitSummary => ({
   sceneIdChanged: commit.scene.id !== commit.previousScene?.id,
   activeCameraChanged: commit.scene.activeCameraId !== commit.previousScene?.activeCameraId,
-  rootNodeIdsChanged: JSON.stringify(commit.scene.rootNodeIds) !==
-    JSON.stringify(commit.previousScene?.rootNodeIds ?? []),
+  rootNodeIdsChanged: fingerprintValue(commit.scene.rootNodeIds) !==
+    fingerprintValue(commit.previousScene?.rootNodeIds ?? []),
   assets: compareSceneRootCollection(commit.scene.assets, commit.previousScene?.assets),
   textures: compareSceneRootCollection(commit.scene.textures, commit.previousScene?.textures),
   materials: compareSceneRootCollection(commit.scene.materials, commit.previousScene?.materials),
@@ -105,6 +193,18 @@ export const summarizeSceneRootCommit = (commit: SceneRootCommit): SceneRootComm
     commit.previousScene?.animationClips,
   ),
 });
+
+export const commitSummaryNeedsResidencyReset = (summary: SceneRootCommitSummary): boolean => {
+  return summary.sceneIdChanged ||
+    summary.rootNodeIdsChanged ||
+    collectionHasChanges(summary.assets) ||
+    collectionHasChanges(summary.textures) ||
+    collectionHasChanges(summary.materials) ||
+    collectionHasChanges(summary.meshes) ||
+    collectionHasChanges(summary.sdfPrimitives) ||
+    collectionHasChanges(summary.volumePrimitives) ||
+    collectionHasChanges(summary.nodes);
+};
 
 export const createSceneRoot = (initialElement?: AuthoringElement): SceneRoot => {
   let currentScene: SceneIr | undefined;

--- a/tests/react_authoring_test.tsx
+++ b/tests/react_authoring_test.tsx
@@ -5,6 +5,7 @@ import { assertEquals, assertThrows } from 'jsr:@std/assert@^1.0.14';
 import { identityTransform } from '@rieul3d/ir';
 import {
   authoringTreeToSceneIr,
+  commitSummaryNeedsResidencyReset,
   createAuthoringElement,
   createSceneRoot,
   Fragment,
@@ -629,6 +630,98 @@ Deno.test('summarizeSceneRootCommit distinguishes added removed and updated stab
       unchangedIds: ['triangle-node'],
     },
     animationClips: { addedIds: [], removedIds: [], updatedIds: [], unchangedIds: [] },
+  });
+});
+
+Deno.test('commitSummaryNeedsResidencyReset stays true for node-only topology changes', () => {
+  const root = createSceneRoot();
+  const resets: boolean[] = [];
+
+  root.subscribe((commit) => {
+    resets.push(commitSummaryNeedsResidencyReset(summarizeSceneRootCommit(commit)));
+  });
+
+  root.render(
+    <scene id='jsx-scene'>
+      <mesh
+        id='triangle'
+        attributes={[{
+          semantic: 'POSITION',
+          itemSize: 3,
+          values: [0, 0.7, 0, -0.7, -0.7, 0, 0.7, -0.7, 0],
+        }]}
+      />
+      <group id='scene-root'>
+        <node id='triangle-node' meshId='triangle' />
+      </group>
+    </scene>,
+  );
+
+  root.render(
+    <scene id='jsx-scene'>
+      <mesh
+        id='triangle'
+        attributes={[{
+          semantic: 'POSITION',
+          itemSize: 3,
+          values: [0, 0.7, 0, -0.7, -0.7, 0, 0.7, -0.7, 0],
+        }]}
+      />
+      <group id='scene-root'>
+        <node id='triangle-node-next' meshId='triangle' />
+      </group>
+    </scene>,
+  );
+
+  assertEquals(resets, [true, true]);
+});
+
+Deno.test('summarizeSceneRootCommit keeps unchanged large mesh payloads stable', () => {
+  const root = createSceneRoot();
+  const summaries: ReturnType<typeof summarizeSceneRootCommit>[] = [];
+  const largeAttributeValues = Array.from({ length: 4096 }, (_, index) => index / 10);
+
+  root.subscribe((commit) => {
+    summaries.push(summarizeSceneRootCommit(commit));
+  });
+
+  root.render(
+    <scene id='jsx-scene'>
+      <mesh
+        id='large-mesh'
+        attributes={[{
+          semantic: 'POSITION',
+          itemSize: 4,
+          values: largeAttributeValues,
+        }]}
+      />
+      <group id='scene-root'>
+        <node id='mesh-node' meshId='large-mesh' />
+      </group>
+    </scene>,
+  );
+
+  root.render(
+    <scene id='jsx-scene'>
+      <mesh
+        id='large-mesh'
+        attributes={[{
+          semantic: 'POSITION',
+          itemSize: 4,
+          values: [...largeAttributeValues],
+        }]}
+      />
+      <group id='scene-root'>
+        <node id='mesh-node' meshId='large-mesh' />
+      </group>
+    </scene>,
+  );
+
+  assertEquals(summaries[1]?.meshes, {
+    addedIds: [],
+    removedIds: [],
+    updatedIds: [],
+    unchangedIds: ['large-mesh'],
   });
 });
 


### PR DESCRIPTION
## Summary
- add `summarizeSceneRootCommit()` so snapshot subscribers can derive per-resource added/removed/updated/unchanged IDs without a new diff/apply contract
- update the browser React authoring example to use commit summaries before resetting residency caches
- document the new snapshot-summary path in the React authoring spec and ADR 0007, and register targeted GPU invalidation follow-up issue #92

## Testing
- deno test --unstable-raw-imports tests/react_authoring_test.tsx
- deno task docs:check
- deno task example:browser:react:build
- deno task check

Refs #89
Refs #90
Refs #92
