### PR TITLE
Add targeted residency invalidation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Implemented today:
   custom lit shader for mesh normals
 - a browser React authoring example plus scene-root bridge that commits JSX-authored trees into
   `SceneIr` snapshots before rendering, including JSX-authored scene resources such as meshes,
-  materials, and cameras, with commit-summary helpers for the current runtime-safe residency reset
-  boundary
+  materials, and cameras, with commit-summary plus targeted residency invalidation helpers for the
+  current runtime-safe update boundary
 - proposed ADR/discussion tracking for the next React live-update boundary decision: whether
   scene-root commits should stay snapshot-only or expose diff/apply metadata
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -84,6 +84,9 @@ diff/apply payload for committed changes? That follow-up remains Proposed pendin
   residency when a new committed snapshot replaces resource contents under stable IDs; commit
   summaries now let them scope that rebuild without missing node-only changes that can remap which
   stable resources remain live.
+- `@rieul3d/gpu` now exposes ID-keyed targeted invalidation helpers, so snapshot consumers can drop
+  only the changed mesh/material/texture/volume residency entries before falling back to a full
+  reset for scene-topology changes.
 - Rendering, residency preparation, and execution continue to live in the core/gpu/renderer layers.
 - The browser example now demonstrates full-scene JSX authoring plus scene-root snapshot commits,
   not a live React reconciler.
@@ -93,6 +96,6 @@ diff/apply payload for committed changes? That follow-up remains Proposed pendin
   question.
 - [`../../examples/browser_react_authoring/README.md`](../../examples/browser_react_authoring/README.md)
   shows the reference browser flow: author a tree with `@rieul3d/react` TSX, commit it through
-  `createSceneRoot()`, summarize that commit, apply `commitSummaryNeedsResidencyReset()` for the
-  current runtime-safe invalidation boundary, then hand the published scene snapshot to the existing
-  runtime and renderer layers.
+  `createSceneRoot()`, summarize that commit, drop targeted residency entries where stable resource
+  IDs changed, fall back to a full reset for scene-topology changes, then hand the published scene
+  snapshot to the existing runtime and renderer layers.

--- a/docs/specs/runtime-residency.md
+++ b/docs/specs/runtime-residency.md
@@ -37,6 +37,8 @@ from Scene IR so the same IR can run in browsers, Deno, and headless targets.
 
 - Device-local residency is invalidatable and rebuildable from
   `AssetSource + SceneIr + EvaluatedScene`.
+- Callers may now drop targeted mesh/material/texture/volume residency entries by stable IDs when a
+  full rebuild is not required.
 - Pipeline caches are considered disposable and are cleared during rebuild.
 - Device loss is observed explicitly rather than hidden behind global runtime state.
 - Browser examples exercise both `ensureSceneMeshResidency(...)` and

--- a/examples/browser_react_authoring/README.md
+++ b/examples/browser_react_authoring/README.md
@@ -6,8 +6,9 @@ node transform shorthands such as `position`, commits that tree through `createS
 renders the published `SceneIr` snapshot through the browser forward pipeline. Resource-only aliases
 remain available when no node binding props or children are supplied. Because the bridge publishes
 whole-scene snapshots, the example also uses `summarizeSceneRootCommit()` together with
-`commitSummaryNeedsResidencyReset()` so cached GPU residency still resets for resource or node
-topology changes before the next frame upload.
+`@rieul3d/gpu` targeted invalidation helpers so cached GPU residency can drop changed
+mesh/material/texture/volume entries by ID before falling back to a full reset for node topology
+changes.
 
 This is now a real JSX authoring example with the first scene-root bridge, but it is still not a
 live React renderer or reconciler. `@rieul3d/react` currently owns authoring, snapshot commits, and

--- a/examples/browser_react_authoring/main.tsx
+++ b/examples/browser_react_authoring/main.tsx
@@ -8,12 +8,13 @@ import {
   createRuntimeResidency,
   ensureSceneMeshResidency,
   invalidateResidency,
+  invalidateResidencyResources,
   requestGpuContext,
 } from '../../packages/gpu/mod.ts';
 import { createBrowserSurfaceTarget } from '../../packages/platform/mod.ts';
 import {
-  commitSummaryNeedsResidencyReset,
   createSceneRoot,
+  type SceneRootCommit,
   summarizeSceneRootCommit,
 } from '../../packages/react/mod.ts';
 import { createMaterialRegistry, renderForwardFrame } from '../../packages/renderer/mod.ts';
@@ -66,11 +67,90 @@ const sceneRoot = createSceneRoot();
 let scene = sceneRoot.getScene();
 const residency = createRuntimeResidency();
 
+const collectAssetLinkedIds = (
+  commit: SceneRootCommit,
+  assetIds: readonly string[],
+): Readonly<{
+  textureIds: readonly string[];
+  volumeIds: readonly string[];
+}> => {
+  const changedAssetIds = new Set(assetIds);
+  const scenes = [commit.previousScene, commit.scene].filter((
+    candidate,
+  ): candidate is typeof commit.scene => candidate !== undefined);
+  const textureIds = new Set<string>();
+  const volumeIds = new Set<string>();
+
+  for (const candidateScene of scenes) {
+    for (const texture of candidateScene.textures) {
+      if (texture.assetId && changedAssetIds.has(texture.assetId)) {
+        textureIds.add(texture.id);
+      }
+    }
+
+    for (const volume of candidateScene.volumePrimitives) {
+      if (volume.assetId && changedAssetIds.has(volume.assetId)) {
+        volumeIds.add(volume.id);
+      }
+    }
+  }
+
+  return {
+    textureIds: [...textureIds],
+    volumeIds: [...volumeIds],
+  };
+};
+
 sceneRoot.subscribe((commit) => {
   scene = commit.scene;
-  if (commitSummaryNeedsResidencyReset(summarizeSceneRootCommit(commit))) {
+  const summary = summarizeSceneRootCommit(commit);
+  if (
+    summary.sceneIdChanged ||
+    summary.rootNodeIdsChanged ||
+    summary.nodes.addedIds.length > 0 ||
+    summary.nodes.removedIds.length > 0 ||
+    summary.nodes.updatedIds.length > 0 ||
+    summary.sdfPrimitives.addedIds.length > 0 ||
+    summary.sdfPrimitives.removedIds.length > 0 ||
+    summary.sdfPrimitives.updatedIds.length > 0
+  ) {
     invalidateResidency(residency);
+    return;
   }
+
+  const assetLinkedIds = collectAssetLinkedIds(
+    commit,
+    [
+      ...summary.assets.addedIds,
+      ...summary.assets.removedIds,
+      ...summary.assets.updatedIds,
+    ],
+  );
+
+  invalidateResidencyResources(residency, {
+    meshIds: [
+      ...summary.meshes.addedIds,
+      ...summary.meshes.removedIds,
+      ...summary.meshes.updatedIds,
+    ],
+    materialIds: [
+      ...summary.materials.addedIds,
+      ...summary.materials.removedIds,
+      ...summary.materials.updatedIds,
+    ],
+    textureIds: [
+      ...summary.textures.addedIds,
+      ...summary.textures.removedIds,
+      ...summary.textures.updatedIds,
+      ...assetLinkedIds.textureIds,
+    ],
+    volumeIds: [
+      ...summary.volumePrimitives.addedIds,
+      ...summary.volumePrimitives.removedIds,
+      ...summary.volumePrimitives.updatedIds,
+      ...assetLinkedIds.volumeIds,
+    ],
+  });
 });
 sceneRoot.render(<TriangleScene />);
 

--- a/packages/gpu/src/residency.ts
+++ b/packages/gpu/src/residency.ts
@@ -73,6 +73,14 @@ export type RuntimeResidency = {
   readonly pipelines: Map<string, GPURenderPipeline | GPUComputePipeline>;
 };
 
+export type ResidencyInvalidationPlan = Readonly<{
+  meshIds?: readonly string[];
+  materialIds?: readonly string[];
+  textureIds?: readonly string[];
+  volumeIds?: readonly string[];
+  pipelineKeys?: readonly string[];
+}>;
+
 export const createRuntimeResidency = (): RuntimeResidency => ({
   textures: new Map(),
   geometry: new Map(),
@@ -94,12 +102,66 @@ export const describeResidencyInputs = (
   nodeCount: evaluatedScene.nodes.length,
 });
 
+const destroyGeometryResidency = (geometry: GeometryResidency): void => {
+  for (const buffer of Object.values(geometry.attributeBuffers)) {
+    buffer.destroy();
+  }
+
+  geometry.indexBuffer?.destroy();
+};
+
+const destroyMaterialResidency = (material: MaterialResidency): void => {
+  material.uniformBuffer.destroy();
+};
+
+const destroyTextureResidency = (texture: TextureResidency): void => {
+  texture.texture.destroy();
+};
+
+const destroyVolumeResidency = (volume: VolumeResidency): void => {
+  volume.texture.destroy();
+};
+
+const deleteResidencyEntries = <TEntry>(
+  cache: Map<string, TEntry>,
+  ids: readonly string[] | undefined,
+  destroyEntry: (entry: TEntry) => void,
+): void => {
+  for (const id of ids ?? []) {
+    const cached = cache.get(id);
+    if (!cached) {
+      continue;
+    }
+
+    destroyEntry(cached);
+    cache.delete(id);
+  }
+};
+
+export const invalidateResidencyResources = (
+  residency: RuntimeResidency,
+  plan: ResidencyInvalidationPlan,
+): RuntimeResidency => {
+  deleteResidencyEntries(residency.geometry, plan.meshIds, destroyGeometryResidency);
+  deleteResidencyEntries(residency.materials, plan.materialIds, destroyMaterialResidency);
+  deleteResidencyEntries(residency.textures, plan.textureIds, destroyTextureResidency);
+  deleteResidencyEntries(residency.volumes, plan.volumeIds, destroyVolumeResidency);
+
+  for (const pipelineKey of plan.pipelineKeys ?? []) {
+    residency.pipelines.delete(pipelineKey);
+  }
+
+  return residency;
+};
+
 export const invalidateResidency = (residency: RuntimeResidency): RuntimeResidency => {
-  residency.textures.clear();
-  residency.geometry.clear();
-  residency.materials.clear();
-  residency.volumes.clear();
-  residency.pipelines.clear();
+  invalidateResidencyResources(residency, {
+    meshIds: [...residency.geometry.keys()],
+    materialIds: [...residency.materials.keys()],
+    textureIds: [...residency.textures.keys()],
+    volumeIds: [...residency.volumes.keys()],
+    pipelineKeys: [...residency.pipelines.keys()],
+  });
   return residency;
 };
 

--- a/tests/residency_invalidation_test.ts
+++ b/tests/residency_invalidation_test.ts
@@ -1,0 +1,150 @@
+import { assertEquals } from 'jsr:@std/assert@^1.0.14';
+import {
+  createRuntimeResidency,
+  invalidateResidency,
+  invalidateResidencyResources,
+} from '@rieul3d/gpu';
+
+const createMockBuffer = () => {
+  let destroyed = false;
+  return {
+    get destroyed() {
+      return destroyed;
+    },
+    destroy: () => {
+      destroyed = true;
+    },
+  } as GPUBuffer & { readonly destroyed: boolean };
+};
+
+const createMockTexture = () => {
+  let destroyed = false;
+  return {
+    get destroyed() {
+      return destroyed;
+    },
+    destroy: () => {
+      destroyed = true;
+    },
+  } as GPUTexture & { readonly destroyed: boolean };
+};
+
+Deno.test('invalidateResidencyResources drops only selected residency ids', () => {
+  const geometryBuffer = createMockBuffer();
+  const materialBuffer = createMockBuffer();
+  const texture = createMockTexture();
+  const volume = createMockTexture();
+  const residency = createRuntimeResidency();
+
+  residency.geometry.set('mesh-a', {
+    meshId: 'mesh-a',
+    attributeBuffers: { POSITION: geometryBuffer },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  residency.geometry.set('mesh-b', {
+    meshId: 'mesh-b',
+    attributeBuffers: { POSITION: createMockBuffer() },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+  residency.materials.set('material-a', {
+    materialId: 'material-a',
+    parameterNames: ['color'],
+    uniformData: new Float32Array(4),
+    uniformBuffer: materialBuffer,
+  });
+  residency.textures.set('texture-a', {
+    textureId: 'texture-a',
+    texture,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm',
+  });
+  residency.volumes.set('volume-a', {
+    volumeId: 'volume-a',
+    texture: volume,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 1,
+    height: 1,
+    depth: 1,
+    format: 'r8unorm',
+  });
+  residency.pipelines.set('pipeline-a', {} as GPURenderPipeline);
+  residency.pipelines.set('pipeline-b', {} as GPURenderPipeline);
+
+  invalidateResidencyResources(residency, {
+    meshIds: ['mesh-a'],
+    materialIds: ['material-a'],
+    textureIds: ['texture-a'],
+    volumeIds: ['volume-a'],
+    pipelineKeys: ['pipeline-a'],
+  });
+
+  assertEquals(geometryBuffer.destroyed, true);
+  assertEquals(materialBuffer.destroyed, true);
+  assertEquals(texture.destroyed, true);
+  assertEquals(volume.destroyed, true);
+  assertEquals([...residency.geometry.keys()], ['mesh-b']);
+  assertEquals([...residency.materials.keys()], []);
+  assertEquals([...residency.textures.keys()], []);
+  assertEquals([...residency.volumes.keys()], []);
+  assertEquals([...residency.pipelines.keys()], ['pipeline-b']);
+});
+
+Deno.test('invalidateResidency destroys and clears every cached residency class', () => {
+  const geometryBuffer = createMockBuffer();
+  const materialBuffer = createMockBuffer();
+  const texture = createMockTexture();
+  const volume = createMockTexture();
+  const residency = createRuntimeResidency();
+
+  residency.geometry.set('mesh-a', {
+    meshId: 'mesh-a',
+    attributeBuffers: { POSITION: geometryBuffer },
+    indexBuffer: createMockBuffer(),
+    vertexCount: 3,
+    indexCount: 3,
+  });
+  residency.materials.set('material-a', {
+    materialId: 'material-a',
+    parameterNames: ['color'],
+    uniformData: new Float32Array(4),
+    uniformBuffer: materialBuffer,
+  });
+  residency.textures.set('texture-a', {
+    textureId: 'texture-a',
+    texture,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm',
+  });
+  residency.volumes.set('volume-a', {
+    volumeId: 'volume-a',
+    texture: volume,
+    view: {} as GPUTextureView,
+    sampler: {} as GPUSampler,
+    width: 1,
+    height: 1,
+    depth: 1,
+    format: 'r8unorm',
+  });
+  residency.pipelines.set('pipeline-a', {} as GPURenderPipeline);
+
+  invalidateResidency(residency);
+
+  assertEquals(geometryBuffer.destroyed, true);
+  assertEquals(materialBuffer.destroyed, true);
+  assertEquals(texture.destroyed, true);
+  assertEquals(volume.destroyed, true);
+  assertEquals(residency.geometry.size, 0);
+  assertEquals(residency.materials.size, 0);
+  assertEquals(residency.textures.size, 0);
+  assertEquals(residency.volumes.size, 0);
+  assertEquals(residency.pipelines.size, 0);
+});


### PR DESCRIPTION
## Summary
- add targeted `@rieul3d/gpu` residency invalidation helpers keyed by stable resource IDs
- update the browser React authoring example to drop only changed resource caches before falling back to full resets for topology changes
- document the new runtime boundary and add residency invalidation regression coverage

## Testing
- `deno test --unstable-raw-imports tests/residency_invalidation_test.ts tests/react_authoring_test.tsx tests/mesh_residency_test.ts tests/material_residency_test.ts tests/texture_residency_test.ts tests/volume_residency_test.ts`
- `deno lint packages/gpu/src/residency.ts examples/browser_react_authoring/main.tsx tests/residency_invalidation_test.ts`
- `deno task example:browser:react:build`
- `deno task docs:check`

Closes #92.
