### PR TITLE
react: add convenience scene object components

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Implemented today:
   custom lit shader for mesh normals
 - a browser React authoring example plus the current `createSceneRoot()` snapshot path that commits
   JSX-authored trees into `SceneIr` snapshots before rendering, including JSX-authored scene
-  resources such as meshes, materials, and cameras, with commit-summary plus targeted residency
-  invalidation helpers for the current runtime-safe update boundary
+  resources such as meshes, materials, and cameras, exported convenience components for common
+  camera/light composition, and commit-summary plus targeted residency invalidation helpers for the
+  current runtime-safe update boundary
 - proposed ADR/discussion tracking for the next React live-update boundary decision around
   partial-apply scene updates without renderer ownership
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Use this page as the main navigation hub.
 - Review accepted architecture constraints: [`adr/README.md`](./adr/README.md)
 - Review the JSX authoring boundary decision:
   [`adr/0004-react-jsx-authoring.md`](./adr/0004-react-jsx-authoring.md)
-- Review the proposed React scene update boundary decision:
+- Review the accepted React scene update boundary decision:
   [`adr/0006-react-scene-root-bridge.md`](./adr/0006-react-scene-root-bridge.md)
 - Run the browser and native examples, including the textured and custom-material browser workflows:
   [`../examples/README.md`](../examples/README.md)

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -14,7 +14,8 @@ React integration is a separate package. It must not become the source of truth 
   node-oriented Scene IR structure.
 - Higher-level camera/light composition should prefer React convenience components built from
   `<camera>`, `<light>`, and `<node>` instead of expanding the primitive JSX surface with more
-  built-in combined object tags.
+  built-in combined object tags; the package now exports `PerspectiveCamera`, `OrthographicCamera`,
+  and `DirectionalLight` as the first shared examples of that pattern.
 - Node-like authoring elements may use transform shorthands such as `position`, `rotation`, and
   `scale`; these fold into the existing Scene IR transform object during lowering.
 - Authored trees are lowered into complete Scene IR or evaluated scene inputs.
@@ -66,12 +67,15 @@ full-snapshot publication shape as the final contract.
 - The package now exposes a JSX runtime so TSX can author scene trees directly.
 - Authoring nodes lower core node metadata such as names, mesh/camera/light bindings, and transforms
   into Scene IR, including React-style `position`/`rotation`/`scale` shorthands.
-- The JSX surface currently includes group-style node aliases and still carries some built-in
-  combined camera/light aliases from the first authoring pass.
+- The JSX surface currently includes group-style node aliases, while common camera/light composition
+  can now be authored through exported convenience components instead of relying on built-in
+  combined intrinsics.
 - Root scene trees can now also declare cameras, meshes, materials, lights, textures, and assets in
   the same TSX surface before lowering.
 - The preferred long-term direction is to move camera/light convenience toward reusable React
   components while keeping primitive JSX authoring tied to explicit IR concepts.
+- `PerspectiveCamera`, `OrthographicCamera`, and `DirectionalLight` now compose those explicit
+  primitives into reusable React-facing scene objects without changing the underlying IR semantics.
 - `createSceneRoot()` now provides a data-only commit bridge that publishes full `SceneIr` snapshots
   plus previous-scene/revision metadata to caller-owned subscribers as a current implementation
   waypoint.

--- a/examples/browser_react_authoring/README.md
+++ b/examples/browser_react_authoring/README.md
@@ -1,7 +1,7 @@
 # Browser React Authoring Example
 
 This example shows the current bridge between `@rieul3d/react` and the existing runtime layers. It
-authors a scene with TSX, including the current built-in `perspectiveCamera` alias plus node
+authors a scene with TSX, including the exported `PerspectiveCamera` convenience component plus node
 transform shorthands such as `position`, commits that tree through `createSceneRoot()`, then renders
 the published `SceneIr` snapshot through the browser forward pipeline. Because the bridge publishes
 whole-scene snapshots, the example also uses `summarizeSceneRootCommit()` together with
@@ -9,9 +9,9 @@ whole-scene snapshots, the example also uses `summarizeSceneRootCommit()` togeth
 mesh/material/texture/volume entries by ID before falling back to a full reset for node topology
 changes.
 
-The long-term direction is to move camera/light convenience toward reusable React components while
-keeping primitive JSX authoring closer to explicit Scene IR concepts such as `<camera>`, `<light>`,
-and `<node>`.
+The example now follows ADR 0005's preferred direction: camera/light convenience lives in reusable
+React components while primitive JSX authoring stays closer to explicit Scene IR concepts such as
+`<camera>`, `<light>`, and `<node>`.
 
 This is now a real JSX authoring example with the current snapshot-based `createSceneRoot()` path,
 but it is still not a live React renderer or reconciler. `@rieul3d/react` currently owns authoring,

--- a/examples/browser_react_authoring/main.tsx
+++ b/examples/browser_react_authoring/main.tsx
@@ -14,6 +14,7 @@ import {
 import { createBrowserSurfaceTarget } from '../../packages/platform/mod.ts';
 import {
   createSceneRoot,
+  PerspectiveCamera,
   type SceneRootCommit,
   summarizeSceneRootCommit,
 } from '../../packages/react/mod.ts';
@@ -56,7 +57,7 @@ const TriangleScene = () => (
         ],
       }]}
     />
-    <perspectiveCamera id='camera-main' position={[0, 0, 2]} />
+    <PerspectiveCamera id='camera-main' position={[0, 0, 2]} />
     <group id='scene-root' name='Authored Root'>
       <node id='triangle-node' name='Authored Triangle' meshId='triangle' />
     </group>

--- a/packages/react/src/authoring.ts
+++ b/packages/react/src/authoring.ts
@@ -163,6 +163,9 @@ export type DirectionalLightJsxProps = Readonly<
   & Omit<Light, 'id' | 'kind'>
   & SceneObjectAliasNodeProps
 >;
+export type PerspectiveCameraProps = PerspectiveCameraJsxProps;
+export type OrthographicCameraProps = OrthographicCameraJsxProps;
+export type DirectionalLightProps = DirectionalLightJsxProps;
 
 type AuthoringComponent<Props> = (
   props: Props & {
@@ -388,6 +391,108 @@ const hasSceneObjectAliasNodeIntent = (
   nodeProps.rotation !== undefined ||
   nodeProps.scale !== undefined;
 
+const buildPerspectiveCameraElement = (
+  props: PerspectiveCameraJsxProps,
+  key?: string,
+): AuthoringElement => {
+  const {
+    id,
+    children: rawChildren,
+    nodeId,
+    name,
+    transform,
+    position,
+    rotation,
+    scale,
+    ...cameraProps
+  } = props;
+  const children = flattenAuthoringChildren(rawChildren);
+  const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
+  if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
+    return createAuthoringElement('camera', id, { ...cameraProps, type: 'perspective' });
+  }
+  return createSceneObjectAliasElement(
+    'camera',
+    id,
+    { ...cameraProps, type: 'perspective' },
+    aliasNodeProps,
+    { cameraId: id },
+    children,
+    key,
+  );
+};
+
+const buildOrthographicCameraElement = (
+  props: OrthographicCameraJsxProps,
+  key?: string,
+): AuthoringElement => {
+  const {
+    id,
+    children: rawChildren,
+    nodeId,
+    name,
+    transform,
+    position,
+    rotation,
+    scale,
+    ...cameraProps
+  } = props;
+  const children = flattenAuthoringChildren(rawChildren);
+  const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
+  if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
+    return createAuthoringElement('camera', id, { ...cameraProps, type: 'orthographic' });
+  }
+  return createSceneObjectAliasElement(
+    'camera',
+    id,
+    { ...cameraProps, type: 'orthographic' },
+    aliasNodeProps,
+    { cameraId: id },
+    children,
+    key,
+  );
+};
+
+const buildDirectionalLightElement = (
+  props: DirectionalLightJsxProps,
+  key?: string,
+): AuthoringElement => {
+  const {
+    id,
+    children: rawChildren,
+    nodeId,
+    name,
+    transform,
+    position,
+    rotation,
+    scale,
+    ...lightProps
+  } = props;
+  const children = flattenAuthoringChildren(rawChildren);
+  const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
+  if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
+    return createAuthoringElement('light', id, { ...lightProps, kind: 'directional' });
+  }
+  return createSceneObjectAliasElement(
+    'light',
+    id,
+    { ...lightProps, kind: 'directional' },
+    aliasNodeProps,
+    { lightId: id },
+    children,
+    key,
+  );
+};
+
+export const PerspectiveCamera = (props: PerspectiveCameraProps): AuthoringElement =>
+  buildPerspectiveCameraElement(props);
+
+export const OrthographicCamera = (props: OrthographicCameraProps): AuthoringElement =>
+  buildOrthographicCameraElement(props);
+
+export const DirectionalLight = (props: DirectionalLightProps): AuthoringElement =>
+  buildDirectionalLightElement(props);
+
 export const jsx = (
   type:
     | keyof AuthoringPropsByType
@@ -444,84 +549,15 @@ export const jsx = (
   }
 
   if (type === 'perspectiveCamera') {
-    const {
-      id,
-      children: _children,
-      nodeId,
-      name,
-      transform,
-      position,
-      rotation,
-      scale,
-      ...cameraProps
-    } = authoringProps as PerspectiveCameraJsxProps;
-    const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
-    if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
-      return createAuthoringElement('camera', id, { ...cameraProps, type: 'perspective' });
-    }
-    return createSceneObjectAliasElement(
-      'camera',
-      id,
-      { ...cameraProps, type: 'perspective' },
-      aliasNodeProps,
-      { cameraId: id },
-      children,
-      key,
-    );
+    return buildPerspectiveCameraElement(authoringProps as PerspectiveCameraJsxProps, key);
   }
 
   if (type === 'orthographicCamera') {
-    const {
-      id,
-      children: _children,
-      nodeId,
-      name,
-      transform,
-      position,
-      rotation,
-      scale,
-      ...cameraProps
-    } = authoringProps as OrthographicCameraJsxProps;
-    const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
-    if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
-      return createAuthoringElement('camera', id, { ...cameraProps, type: 'orthographic' });
-    }
-    return createSceneObjectAliasElement(
-      'camera',
-      id,
-      { ...cameraProps, type: 'orthographic' },
-      aliasNodeProps,
-      { cameraId: id },
-      children,
-      key,
-    );
+    return buildOrthographicCameraElement(authoringProps as OrthographicCameraJsxProps, key);
   }
 
   if (type === 'directionalLight') {
-    const {
-      id,
-      children: _children,
-      nodeId,
-      name,
-      transform,
-      position,
-      rotation,
-      scale,
-      ...lightProps
-    } = authoringProps as DirectionalLightJsxProps;
-    const aliasNodeProps = { nodeId, name, transform, position, rotation, scale };
-    if (!hasSceneObjectAliasNodeIntent(aliasNodeProps, children)) {
-      return createAuthoringElement('light', id, { ...lightProps, kind: 'directional' });
-    }
-    return createSceneObjectAliasElement(
-      'light',
-      id,
-      { ...lightProps, kind: 'directional' },
-      aliasNodeProps,
-      { lightId: id },
-      children,
-      key,
-    );
+    return buildDirectionalLightElement(authoringProps as DirectionalLightJsxProps, key);
   }
 
   if (

--- a/tests/react_authoring_test.tsx
+++ b/tests/react_authoring_test.tsx
@@ -8,7 +8,10 @@ import {
   commitSummaryNeedsResidencyReset,
   createAuthoringElement,
   createSceneRoot,
+  DirectionalLight,
   Fragment,
+  OrthographicCamera,
+  PerspectiveCamera,
   summarizeSceneRootCommit,
 } from '@rieul3d/react';
 
@@ -362,6 +365,51 @@ Deno.test('authoringTreeToSceneIr lowers react-style alias intrinsics', () => {
   });
 });
 
+Deno.test('authoringTreeToSceneIr lowers exported convenience components through primitives', () => {
+  const scene = authoringTreeToSceneIr(
+    <scene id='jsx-scene' activeCameraId='camera-main'>
+      <PerspectiveCamera id='camera-main' yfov={0.8} position={[0, 0, 2]}>
+        <node id='camera-child' />
+      </PerspectiveCamera>
+      <DirectionalLight
+        id='sun'
+        color={{ x: 1, y: 0.95, z: 0.9 }}
+        intensity={1.5}
+        nodeId='sun-node'
+        position={[1, 2, 3]}
+      />
+      <OrthographicCamera id='camera-close' xmag={0.8} ymag={0.8} />
+    </scene>,
+  );
+
+  assertEquals(scene.activeCameraId, 'camera-main');
+  assertEquals(scene.cameras, [
+    {
+      id: 'camera-main',
+      type: 'perspective',
+      yfov: 0.8,
+      znear: 0.1,
+      zfar: 100,
+    },
+    {
+      id: 'camera-close',
+      type: 'orthographic',
+      xmag: 0.8,
+      ymag: 0.8,
+      znear: 0,
+      zfar: 100,
+    },
+  ]);
+  assertEquals(scene.lights[0], {
+    id: 'sun',
+    kind: 'directional',
+    color: { x: 1, y: 0.95, z: 0.9 },
+    intensity: 1.5,
+  });
+  assertEquals(scene.rootNodeIds, ['camera-main', 'sun-node']);
+  assertEquals(scene.nodes.map((node) => node.id), ['camera-main', 'camera-child', 'sun-node']);
+});
+
 Deno.test('react-style aliases stay resource-only without node intent', () => {
   const cameraProps = {
     type: 'orthographic' as const,
@@ -411,6 +459,23 @@ Deno.test('react-style aliases preserve their fixed resource kinds when props ar
     <scene id='jsx-scene' activeCameraId='camera-main'>
       <perspectiveCamera id='camera-main' {...cameraProps} />
       <directionalLight id='sun' {...lightProps} />
+    </scene>,
+  );
+
+  assertEquals(scene.cameras[0]?.type, 'perspective');
+  assertEquals(scene.lights[0]?.kind, 'directional');
+  assertEquals(scene.nodes, []);
+});
+
+Deno.test('convenience components stay resource-only without node intent', () => {
+  const scene = authoringTreeToSceneIr(
+    <scene id='jsx-scene' activeCameraId='camera-main'>
+      <PerspectiveCamera id='camera-main' yfov={0.8} />
+      <DirectionalLight
+        id='sun'
+        color={{ x: 1, y: 0.95, z: 0.9 }}
+        intensity={1.5}
+      />
     </scene>,
   );
 
@@ -491,7 +556,7 @@ Deno.test('summarizeSceneRootCommit reports first-commit additions', () => {
           values: [0, 0.7, 0, -0.7, -0.7, 0, 0.7, -0.7, 0],
         }]}
       />
-      <perspectiveCamera id='camera-main' position={[0, 0, 2]} />
+      <PerspectiveCamera id='camera-main' position={[0, 0, 2]} />
       <group id='scene-root'>
         <node id='triangle-node' meshId='triangle' />
       </group>
@@ -552,12 +617,12 @@ Deno.test('summarizeSceneRootCommit distinguishes added removed and updated stab
           values: [0, 0.7, 0, -0.7, -0.7, 0, 0.7, -0.7, 0],
         }]}
       />
-      <directionalLight
+      <DirectionalLight
         id='sun'
         color={{ x: 1, y: 0.95, z: 0.9 }}
         intensity={1.5}
       />
-      <perspectiveCamera id='camera-main' position={[0, 0, 2]} />
+      <PerspectiveCamera id='camera-main' position={[0, 0, 2]} />
       <group id='scene-root'>
         <node id='triangle-node' meshId='triangle' />
       </group>
@@ -583,8 +648,8 @@ Deno.test('summarizeSceneRootCommit distinguishes added removed and updated stab
           values: [0, 0.9, 0, -0.8, -0.8, 0, 0.8, -0.8, 0],
         }]}
       />
-      <perspectiveCamera id='camera-main' position={[0, 0, 1.5]} />
-      <orthographicCamera id='camera-close' xmag={0.8} ymag={0.8} />
+      <PerspectiveCamera id='camera-main' position={[0, 0, 1.5]} />
+      <OrthographicCamera id='camera-close' xmag={0.8} ymag={0.8} />
       <group id='scene-root' position={[1, 2, 3]}>
         <node id='triangle-node' meshId='triangle' />
       </group>


### PR DESCRIPTION
## Summary
- add exported PerspectiveCamera, OrthographicCamera, and DirectionalLight convenience components in @rieul3d/react
- route the existing alias intrinsics through the same composition helpers so convenience components and intrinsics lower identically
- update the browser React authoring example, React authoring docs, and regression tests to prefer the exported components

## Testing
- deno test --unstable-raw-imports tests/react_authoring_test.tsx
- deno lint packages/react/src/authoring.ts tests/react_authoring_test.tsx examples/browser_react_authoring/main.tsx
- deno task example:browser:react:build
- deno task docs:check

Closes #96
Related to #64