### PR TITLE
docs: propose react reconciler scene document

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Implemented today:
   camera/light composition, and commit-summary plus update-plan helpers for targeted residency
   invalidation without forcing resets for transform-only node changes
 - proposed ADR/discussion tracking for the next React live-update boundary decision around
-  partial-apply scene updates without renderer ownership
+  partial-apply scene updates without renderer ownership, plus the next proposed reconciler
+  scene-document boundary for issue #112
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and
   recovery rebuild renders, including guards against raymarch fixtures collapsing back to clear-only
   output

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ Use this page as the main navigation hub.
 - Review proposed architecture discussions: [`adr/proposals.md`](./adr/proposals.md)
 - Review the proposed post-processing execution boundary:
   [`adr/0007-post-processing-execution-model.md`](./adr/0007-post-processing-execution-model.md)
+- Review the proposed React reconciler scene-document boundary:
+  [`adr/0008-react-reconciler-scene-document.md`](./adr/0008-react-reconciler-scene-document.md)
 - Review the JSX authoring boundary decision:
   [`adr/0004-react-jsx-authoring.md`](./adr/0004-react-jsx-authoring.md)
 - Review the accepted React scene update boundary decision:

--- a/docs/adr/0008-react-reconciler-scene-document.md
+++ b/docs/adr/0008-react-reconciler-scene-document.md
@@ -1,0 +1,80 @@
+# ADR 0008: React Reconciler Scene Document Boundary
+
+## Status
+
+Proposed
+
+## Decision
+
+`@rieul3d/react` should introduce a real `react-reconciler` host on top of a package-owned scene
+document instead of driving live updates by rebuilding whole `SceneIr` snapshots directly from each
+React commit.
+
+This scene document should be a React-adjacent but renderer-independent object graph that:
+
+- owns stable host instances for scene resources and nodes created by reconciler
+  mount/update/unmount operations
+- preserves explicit parent/child relationships and resource bindings in a form that can be updated
+  incrementally across React commits
+- can derive published data snapshots or update payloads for non-React runtime adapters
+- stays inside `@rieul3d/react` rather than becoming the new public source of truth for core
+  packages
+
+The proposed execution boundary is:
+
+- React components reconcile against host instances owned by `@rieul3d/react`
+- host operations update an internal scene document instead of mutating GPU/runtime state directly
+- the scene document publishes data-only scene snapshots and/or partial-apply update payloads across
+  the boundary preferred by ADR 0006
+- runtime residency, renderer execution, offscreen targets, and multi-scene orchestration remain
+  outside the React package
+
+The first implementation milestone should stay narrow:
+
+- add an internal scene document for authored resources and nodes
+- define stable host-instance identity and update rules for mount, update, insert, and remove
+  operations
+- keep the published output data-oriented so the existing scene-root bridge can coexist during
+  migration
+- avoid public APIs that imply React owns renderer lifecycle or GPU resources
+
+## Rationale
+
+ADR 0004 accepted JSX authoring as React's initial role, and ADR 0006 accepted that the long-term
+boundary should support partial application of scene changes without pulling renderer ownership into
+React. Issue `#112` is the next step in that direction, but a direct jump from today's
+snapshot-lowering helpers to a full reconciler host would leave an important ownership gap.
+
+Without a package-owned scene document:
+
+- reconciler commits would either keep regenerating full `SceneIr` snapshots, which hardens the
+  provisional bridge that ADR 0006 explicitly avoids
+- or host instances would need to mutate residency/renderer state directly, which would violate the
+  existing package layering
+
+An internal scene document gives the reconciler a stable object model to target while preserving the
+current architectural constraint that core runtime packages remain React-independent.
+
+## Consequences
+
+- `@rieul3d/react` gains an internal mutable document/host-instance layer even though its published
+  APIs should remain data-oriented
+- the current `createSceneRoot()` snapshot bridge becomes a compatibility waypoint instead of the
+  only viable React integration path
+- reconciler work can be split into bounded slices: scene document first, host config second,
+  runtime adapter integration third
+- React-driven live updates can evolve without making render targets, portals, or multi-scene
+  composition React-only concepts
+- future public APIs should describe scene data changes and subscriptions, not direct GPU object
+  handles
+
+## Alternatives Considered
+
+- keep whole-scene snapshot regeneration as the reconciler backend: simplest short-term path, but it
+  would formalize the coarse update boundary that ADR 0006 treats as provisional
+- let the reconciler host mutate renderer/runtime state directly: would reduce one layer, but it
+  would collapse the package boundary and make non-React orchestration second-class
+- introduce a public frame-graph or renderer-owned scene document first: too execution-specific for
+  the current React problem, and it would front-load decisions outside issue `#112`'s core scope
+
+Related issues: `#112`, `#117`

--- a/docs/adr/proposals.md
+++ b/docs/adr/proposals.md
@@ -7,6 +7,8 @@ ADR index.
 
 - [`0007-post-processing-execution-model.md`](./0007-post-processing-execution-model.md): introduce
   an explicit scene-color to post-process to present execution boundary
+- [`0008-react-reconciler-scene-document.md`](./0008-react-reconciler-scene-document.md): introduce
+  an internal React-owned scene document before a real reconciler host mutates live scene state
 
 ## Related References
 

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -61,6 +61,12 @@ offscreen targets, and multi-scene orchestration outside the React package. The 
 has a first implementation waypoint in `createSceneRoot()`, but ADR 0006 does not treat that
 full-snapshot publication shape as the final contract.
 
+The next unresolved step for issue `#112` is now captured in
+[`../adr/0008-react-reconciler-scene-document.md`](../adr/0008-react-reconciler-scene-document.md):
+add a React-owned internal scene document that a real `react-reconciler` host can update
+incrementally before those changes cross into the existing runtime/residency boundary. Issue `#117`
+tracks the first implementation slice for that scene-document layer.
+
 ## Current Status
 
 - The React package currently lowers declarative authoring structures into SceneIr-friendly data.
@@ -104,8 +110,13 @@ full-snapshot publication shape as the final contract.
 - The next unresolved architecture question is how React-authored changes should cross into runtime
   update planning so frequent node changes can avoid whole-scene resets while multi-scene
   composition remains outside React ownership.
+- The next unresolved implementation question for a real reconciler host is what internal scene
+  document shape should absorb React mount/update/unmount operations before publishing data-only
+  scene updates outward.
 - Issue `#89` now tracks follow-up implementation work around the next runtime-facing update
   contract.
+- Issue `#117` now tracks the first scene-document implementation slice needed before a true React
+  reconciler host can land.
 - [`../../examples/browser_react_authoring/README.md`](../../examples/browser_react_authoring/README.md)
   shows the reference browser flow: author a tree with `@rieul3d/react` TSX, commit it through
   `createSceneRoot()`, derive an update plan plus summary from that commit, drop targeted residency


### PR DESCRIPTION
## Summary
- add proposed ADR 0008 for the React reconciler scene-document boundary
- link the docs/readme surfaces to the new proposal and the next issue #117 implementation slice
- record #112 follow-up planning without treating the reconciler direction as accepted yet

## Testing
- deno task docs:check

## Related
- refs #112
- refs #117