### PR TITLE
react: add internal scene document

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ Implemented today:
 - a browser React authoring example plus the current `createSceneRoot()` snapshot path that commits
   JSX-authored trees into `SceneIr` snapshots before rendering, including JSX-authored scene
   resources such as meshes, materials, and cameras, exported convenience components for common
-  camera/light composition, and commit-summary plus update-plan helpers for targeted residency
-  invalidation without forcing resets for transform-only node changes
+  camera/light composition, an internal React-owned scene document that preserves stable resource
+  and node host instances across commits before publishing data-only snapshots, and commit-summary
+  plus update-plan helpers for targeted residency invalidation without forcing resets for
+  transform-only node changes
 - proposed ADR/discussion tracking for the next React live-update boundary decision around
-  partial-apply scene updates without renderer ownership
+  partial-apply scene updates without renderer ownership, plus the next proposed reconciler
+  scene-document boundary for issue #112
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and
   recovery rebuild renders, including guards against raymarch fixtures collapsing back to clear-only
   output

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ Use this page as the main navigation hub.
 - Review proposed architecture discussions: [`adr/proposals.md`](./adr/proposals.md)
 - Review the proposed post-processing execution boundary:
   [`adr/0007-post-processing-execution-model.md`](./adr/0007-post-processing-execution-model.md)
+- Review the proposed React reconciler scene-document boundary:
+  [`adr/0008-react-reconciler-scene-document.md`](./adr/0008-react-reconciler-scene-document.md)
 - Review the JSX authoring boundary decision:
   [`adr/0004-react-jsx-authoring.md`](./adr/0004-react-jsx-authoring.md)
 - Review the accepted React scene update boundary decision:
@@ -38,8 +40,8 @@ Use this page as the main navigation hub.
   [`../examples/README.md`](../examples/README.md)
 - Review the React authoring browser example with full-scene TSX lowering and scene-root commits:
   [`../examples/browser_react_authoring/README.md`](../examples/browser_react_authoring/README.md)
-- Review the accepted React scene update planning boundary and current helper surface:
-  [`specs/react-authoring.md`](./specs/react-authoring.md)
+- Review the accepted React scene update planning boundary, internal scene-document waypoint, and
+  current helper surface: [`specs/react-authoring.md`](./specs/react-authoring.md)
 - Run the headless snapshot PNG workflow:
   [`../examples/headless_snapshot/README.md`](../examples/headless_snapshot/README.md)
 

--- a/docs/adr/0008-react-reconciler-scene-document.md
+++ b/docs/adr/0008-react-reconciler-scene-document.md
@@ -1,0 +1,80 @@
+# ADR 0008: React Reconciler Scene Document Boundary
+
+## Status
+
+Proposed
+
+## Decision
+
+`@rieul3d/react` should introduce a real `react-reconciler` host on top of a package-owned scene
+document instead of driving live updates by rebuilding whole `SceneIr` snapshots directly from each
+React commit.
+
+This scene document should be a React-adjacent but renderer-independent object graph that:
+
+- owns stable host instances for scene resources and nodes created by reconciler
+  mount/update/unmount operations
+- preserves explicit parent/child relationships and resource bindings in a form that can be updated
+  incrementally across React commits
+- can derive published data snapshots or update payloads for non-React runtime adapters
+- stays inside `@rieul3d/react` rather than becoming the new public source of truth for core
+  packages
+
+The proposed execution boundary is:
+
+- React components reconcile against host instances owned by `@rieul3d/react`
+- host operations update an internal scene document instead of mutating GPU/runtime state directly
+- the scene document publishes data-only scene snapshots and/or partial-apply update payloads across
+  the boundary preferred by ADR 0006
+- runtime residency, renderer execution, offscreen targets, and multi-scene orchestration remain
+  outside the React package
+
+The first implementation milestone should stay narrow:
+
+- add an internal scene document for authored resources and nodes
+- define stable host-instance identity and update rules for mount, update, insert, and remove
+  operations
+- keep the published output data-oriented so the existing scene-root bridge can coexist during
+  migration
+- avoid public APIs that imply React owns renderer lifecycle or GPU resources
+
+## Rationale
+
+ADR 0004 accepted JSX authoring as React's initial role, and ADR 0006 accepted that the long-term
+boundary should support partial application of scene changes without pulling renderer ownership into
+React. Issue `#112` is the next step in that direction, but a direct jump from today's
+snapshot-lowering helpers to a full reconciler host would leave an important ownership gap.
+
+Without a package-owned scene document:
+
+- reconciler commits would either keep regenerating full `SceneIr` snapshots, which hardens the
+  provisional bridge that ADR 0006 explicitly avoids
+- or host instances would need to mutate residency/renderer state directly, which would violate the
+  existing package layering
+
+An internal scene document gives the reconciler a stable object model to target while preserving the
+current architectural constraint that core runtime packages remain React-independent.
+
+## Consequences
+
+- `@rieul3d/react` gains an internal mutable document/host-instance layer even though its published
+  APIs should remain data-oriented
+- the current `createSceneRoot()` snapshot bridge becomes a compatibility waypoint instead of the
+  only viable React integration path
+- reconciler work can be split into bounded slices: scene document first, host config second,
+  runtime adapter integration third
+- React-driven live updates can evolve without making render targets, portals, or multi-scene
+  composition React-only concepts
+- future public APIs should describe scene data changes and subscriptions, not direct GPU object
+  handles
+
+## Alternatives Considered
+
+- keep whole-scene snapshot regeneration as the reconciler backend: simplest short-term path, but it
+  would formalize the coarse update boundary that ADR 0006 treats as provisional
+- let the reconciler host mutate renderer/runtime state directly: would reduce one layer, but it
+  would collapse the package boundary and make non-React orchestration second-class
+- introduce a public frame-graph or renderer-owned scene document first: too execution-specific for
+  the current React problem, and it would front-load decisions outside issue `#112`'s core scope
+
+Related issues: `#112`, `#117`

--- a/docs/adr/proposals.md
+++ b/docs/adr/proposals.md
@@ -7,6 +7,8 @@ ADR index.
 
 - [`0007-post-processing-execution-model.md`](./0007-post-processing-execution-model.md): introduce
   an explicit scene-color to post-process to present execution boundary
+- [`0008-react-reconciler-scene-document.md`](./0008-react-reconciler-scene-document.md): introduce
+  an internal React-owned scene document before a real reconciler host mutates live scene state
 
 ## Related References
 

--- a/docs/specs/react-authoring.md
+++ b/docs/specs/react-authoring.md
@@ -61,6 +61,12 @@ offscreen targets, and multi-scene orchestration outside the React package. The 
 has a first implementation waypoint in `createSceneRoot()`, but ADR 0006 does not treat that
 full-snapshot publication shape as the final contract.
 
+The next unresolved step for issue `#112` is now captured in
+[`../adr/0008-react-reconciler-scene-document.md`](../adr/0008-react-reconciler-scene-document.md):
+add a React-owned internal scene document that a real `react-reconciler` host can update
+incrementally before those changes cross into the existing runtime/residency boundary. Issue `#117`
+tracks the first implementation slice for that scene-document layer.
+
 ## Current Status
 
 - The React package currently lowers declarative authoring structures into SceneIr-friendly data.
@@ -79,6 +85,11 @@ full-snapshot publication shape as the final contract.
 - `createSceneRoot()` now provides a data-only commit bridge that publishes full `SceneIr` snapshots
   plus previous-scene/revision metadata to caller-owned subscribers as a current implementation
   waypoint.
+- `createSceneRoot()` now keeps an internal React-owned scene document so stable resource and node
+  host instances can survive repeated commits even though the published subscriber payload is still
+  a data-only `SceneIr` snapshot.
+- The scene document currently supports stable node/resource identity, parent-child reordering, and
+  subtree/resource removal as the first package-local waypoint before a real reconciler host lands.
 - `summarizeSceneRootCommit()` can derive resource-level added/removed/updated/unchanged ID sets
   from snapshot commits so integrations can make selective invalidation decisions while a finer
   runtime-facing partial-apply contract is designed.
@@ -104,8 +115,13 @@ full-snapshot publication shape as the final contract.
 - The next unresolved architecture question is how React-authored changes should cross into runtime
   update planning so frequent node changes can avoid whole-scene resets while multi-scene
   composition remains outside React ownership.
+- The next unresolved implementation question for a real reconciler host is what internal scene
+  document shape should absorb React mount/update/unmount operations before publishing data-only
+  scene updates outward.
 - Issue `#89` now tracks follow-up implementation work around the next runtime-facing update
   contract.
+- Issue `#117` now tracks the first scene-document implementation slice needed before a true React
+  reconciler host can land.
 - [`../../examples/browser_react_authoring/README.md`](../../examples/browser_react_authoring/README.md)
   shows the reference browser flow: author a tree with `@rieul3d/react` TSX, commit it through
   `createSceneRoot()`, derive an update plan plus summary from that commit, drop targeted residency

--- a/packages/react/src/authoring.ts
+++ b/packages/react/src/authoring.ts
@@ -1,17 +1,4 @@
-import {
-  appendAsset,
-  appendCamera,
-  appendLight,
-  appendMaterial,
-  appendMesh,
-  appendNode,
-  appendTexture,
-  createNode,
-  createOrthographicCamera,
-  createPerspectiveCamera,
-  createSceneIr,
-  identityTransform,
-} from '@rieul3d/ir';
+import { createOrthographicCamera, createPerspectiveCamera, identityTransform } from '@rieul3d/ir';
 import type {
   AssetRef,
   Camera,
@@ -27,6 +14,16 @@ import type {
   Transform,
   Vec3,
 } from '@rieul3d/ir';
+import {
+  applySceneDocumentScene,
+  createSceneDocument,
+  removeSceneDocumentNode,
+  removeSceneDocumentResource,
+  type SceneDocument,
+  sceneDocumentToSceneIr,
+  upsertSceneDocumentNode,
+  upsertSceneDocumentResource,
+} from './scene_document.ts';
 
 type Vec3Like = Vec3 | readonly [number, number, number];
 type QuatLike = Quat | readonly [number, number, number, number];
@@ -583,63 +580,151 @@ export const jsx = (
 export const jsxs = jsx;
 export const jsxDEV = jsx;
 
-export const authoringTreeToSceneIr = (element: AuthoringElement): SceneIr => {
+const normalizeCamera = (camera: CameraJsxProps): Camera =>
+  camera.type === 'perspective'
+    ? createPerspectiveCamera(camera.id, camera)
+    : createOrthographicCamera(camera.id, camera);
+
+const sweepUnvisitedResourceIds = (
+  document: SceneDocument,
+  kind: 'asset' | 'texture' | 'material' | 'light' | 'mesh' | 'camera',
+  visitedIds: ReadonlySet<string>,
+): void => {
+  const collection = kind === 'asset'
+    ? document.assets.order
+    : kind === 'texture'
+    ? document.textures.order
+    : kind === 'material'
+    ? document.materials.order
+    : kind === 'light'
+    ? document.lights.order
+    : kind === 'mesh'
+    ? document.meshes.order
+    : document.cameras.order;
+  for (const id of [...collection]) {
+    if (!visitedIds.has(id)) {
+      removeSceneDocumentResource(document, kind, id);
+    }
+  }
+};
+
+export const authoringTreeToSceneDocument = (
+  element: AuthoringElement,
+  document = createSceneDocument(element.id),
+): SceneDocument => {
   if (element.type !== 'scene') {
     throw new Error('authoring root must be a scene');
   }
 
-  let scene: SceneIr = createSceneIr(element.id);
   const sceneProps = element.props as SceneAuthoringProps | undefined;
-  if (sceneProps?.activeCameraId) {
-    scene = {
-      ...scene,
-      activeCameraId: sceneProps.activeCameraId,
-    };
-  }
+  applySceneDocumentScene(document, {
+    id: element.id,
+    activeCameraId: sceneProps?.activeCameraId,
+  });
 
-  const normalizeCamera = (camera: CameraJsxProps): Camera =>
-    camera.type === 'perspective'
-      ? createPerspectiveCamera(camera.id, camera)
-      : createOrthographicCamera(camera.id, camera);
+  const visitedNodeIds = new Set<string>();
+  const visitedResourceIds = {
+    asset: new Set<string>(),
+    texture: new Set<string>(),
+    material: new Set<string>(),
+    light: new Set<string>(),
+    mesh: new Set<string>(),
+    camera: new Set<string>(),
+  };
 
-  const visit = (parentId: string | undefined, node: AuthoringElement) => {
+  const visitChildren = (
+    parentId: string | undefined,
+    children: readonly AuthoringElement[],
+    startIndex = 0,
+  ): number => {
+    let nodeIndex = startIndex;
+    for (const child of children) {
+      nodeIndex = visit(parentId, child, nodeIndex);
+    }
+    return nodeIndex;
+  };
+
+  const visit = (
+    parentId: string | undefined,
+    node: AuthoringElement,
+    nodeIndex: number,
+  ): number => {
     switch (node.type) {
       case 'fragment':
-        for (const child of node.children ?? []) visit(parentId, child);
-        return;
+        return visitChildren(parentId, node.children ?? [], nodeIndex);
       case 'node':
-        scene = appendNode(
-          scene,
-          createNode(node.id, {
-            parentId,
-            ...(node.props ?? {}),
-          }),
-        );
-        for (const child of node.children ?? []) visit(node.id, child);
-        return;
+        visitedNodeIds.add(node.id);
+        upsertSceneDocumentNode(document, {
+          id: node.id,
+          parentId,
+          index: nodeIndex,
+          props: node.props as NodeAuthoringProps | undefined,
+        });
+        visitChildren(node.id, node.children ?? []);
+        return nodeIndex + 1;
       case 'asset':
-        scene = appendAsset(scene, node.props as AssetRef);
-        return;
+        visitedResourceIds.asset.add(node.id);
+        upsertSceneDocumentResource(document, {
+          kind: 'asset',
+          value: node.props as AssetRef,
+        });
+        return nodeIndex;
       case 'texture':
-        scene = appendTexture(scene, node.props as TextureRef);
-        return;
+        visitedResourceIds.texture.add(node.id);
+        upsertSceneDocumentResource(document, {
+          kind: 'texture',
+          value: node.props as TextureRef,
+        });
+        return nodeIndex;
       case 'material':
-        scene = appendMaterial(scene, node.props as Material);
-        return;
+        visitedResourceIds.material.add(node.id);
+        upsertSceneDocumentResource(document, {
+          kind: 'material',
+          value: node.props as Material,
+        });
+        return nodeIndex;
       case 'light':
-        scene = appendLight(scene, node.props as Light);
-        return;
+        visitedResourceIds.light.add(node.id);
+        upsertSceneDocumentResource(document, {
+          kind: 'light',
+          value: node.props as Light,
+        });
+        return nodeIndex;
       case 'mesh':
-        scene = appendMesh(scene, node.props as MeshPrimitive);
-        return;
+        visitedResourceIds.mesh.add(node.id);
+        upsertSceneDocumentResource(document, {
+          kind: 'mesh',
+          value: node.props as MeshPrimitive,
+        });
+        return nodeIndex;
       case 'camera':
-        scene = appendCamera(scene, normalizeCamera(node.props as CameraJsxProps));
-        return;
+        visitedResourceIds.camera.add(node.id);
+        upsertSceneDocumentResource(document, {
+          kind: 'camera',
+          value: normalizeCamera(node.props as CameraJsxProps),
+        });
+        return nodeIndex;
       default:
-        return;
+        return nodeIndex;
     }
   };
 
-  for (const child of element.children ?? []) visit(undefined, child);
-  return scene;
+  visitChildren(undefined, element.children ?? []);
+
+  for (const nodeId of [...document.nodes.order].reverse()) {
+    if (!visitedNodeIds.has(nodeId)) {
+      removeSceneDocumentNode(document, nodeId);
+    }
+  }
+  sweepUnvisitedResourceIds(document, 'asset', visitedResourceIds.asset);
+  sweepUnvisitedResourceIds(document, 'texture', visitedResourceIds.texture);
+  sweepUnvisitedResourceIds(document, 'material', visitedResourceIds.material);
+  sweepUnvisitedResourceIds(document, 'light', visitedResourceIds.light);
+  sweepUnvisitedResourceIds(document, 'mesh', visitedResourceIds.mesh);
+  sweepUnvisitedResourceIds(document, 'camera', visitedResourceIds.camera);
+
+  return document;
 };
+
+export const authoringTreeToSceneIr = (element: AuthoringElement): SceneIr =>
+  sceneDocumentToSceneIr(authoringTreeToSceneDocument(element));

--- a/packages/react/src/scene_document.ts
+++ b/packages/react/src/scene_document.ts
@@ -1,0 +1,328 @@
+import {
+  appendAsset,
+  appendCamera,
+  appendLight,
+  appendMaterial,
+  appendMesh,
+  appendNode,
+  appendTexture,
+  createNode,
+  createSceneIr,
+} from '@rieul3d/ir';
+import type {
+  AssetRef,
+  Camera,
+  Light,
+  Material,
+  MeshPrimitive,
+  Node,
+  SceneIr,
+  TextureRef,
+} from '@rieul3d/ir';
+
+type SceneDocumentScene = {
+  id: string;
+  activeCameraId?: string;
+};
+
+export type SceneDocumentNodeInput = Readonly<{
+  id: string;
+  parentId?: string;
+  index?: number;
+  props?: Partial<Omit<Node, 'id' | 'parentId'>>;
+}>;
+
+export type SceneDocumentNodeInstance = {
+  readonly kind: 'node';
+  readonly id: string;
+  parentId?: string;
+  childIds: string[];
+  props: Partial<Omit<Node, 'id' | 'parentId'>>;
+};
+
+type SceneDocumentResourceByKind = {
+  asset: AssetRef;
+  texture: TextureRef;
+  material: Material;
+  light: Light;
+  mesh: MeshPrimitive;
+  camera: Camera;
+};
+
+export type SceneDocumentResourceKind = keyof SceneDocumentResourceByKind;
+
+export type SceneDocumentResourceInput<TKind extends SceneDocumentResourceKind> = Readonly<{
+  kind: TKind;
+  value: SceneDocumentResourceByKind[TKind];
+}>;
+
+export type SceneDocumentResourceInstance<TKind extends SceneDocumentResourceKind> = {
+  readonly kind: TKind;
+  readonly id: string;
+  value: SceneDocumentResourceByKind[TKind];
+};
+
+type SceneDocumentResourceCollection<TKind extends SceneDocumentResourceKind> = {
+  order: string[];
+  byId: Map<string, SceneDocumentResourceInstance<TKind>>;
+};
+
+type SceneDocumentNodeCollection = {
+  order: string[];
+  rootNodeIds: string[];
+  byId: Map<string, SceneDocumentNodeInstance>;
+};
+
+export type SceneDocument = {
+  scene: SceneDocumentScene;
+  assets: SceneDocumentResourceCollection<'asset'>;
+  textures: SceneDocumentResourceCollection<'texture'>;
+  materials: SceneDocumentResourceCollection<'material'>;
+  lights: SceneDocumentResourceCollection<'light'>;
+  meshes: SceneDocumentResourceCollection<'mesh'>;
+  cameras: SceneDocumentResourceCollection<'camera'>;
+  nodes: SceneDocumentNodeCollection;
+};
+
+const createResourceCollection = <
+  TKind extends SceneDocumentResourceKind,
+>(): SceneDocumentResourceCollection<TKind> => ({
+  order: [],
+  byId: new Map<string, SceneDocumentResourceInstance<TKind>>(),
+});
+
+const removeOrderedId = (orderedIds: string[], id: string): void => {
+  const index = orderedIds.indexOf(id);
+  if (index >= 0) {
+    orderedIds.splice(index, 1);
+  }
+};
+
+const insertOrderedId = (orderedIds: string[], id: string, index?: number): void => {
+  removeOrderedId(orderedIds, id);
+  if (index === undefined || index < 0 || index >= orderedIds.length) {
+    orderedIds.push(id);
+    return;
+  }
+  orderedIds.splice(index, 0, id);
+};
+
+const getResourceCollection = <TKind extends SceneDocumentResourceKind>(
+  document: SceneDocument,
+  kind: TKind,
+): SceneDocumentResourceCollection<TKind> => {
+  switch (kind) {
+    case 'asset':
+      return document.assets as SceneDocumentResourceCollection<TKind>;
+    case 'texture':
+      return document.textures as SceneDocumentResourceCollection<TKind>;
+    case 'material':
+      return document.materials as SceneDocumentResourceCollection<TKind>;
+    case 'light':
+      return document.lights as SceneDocumentResourceCollection<TKind>;
+    case 'mesh':
+      return document.meshes as SceneDocumentResourceCollection<TKind>;
+    case 'camera':
+      return document.cameras as SceneDocumentResourceCollection<TKind>;
+  }
+};
+
+const detachNodeInstance = (document: SceneDocument, node: SceneDocumentNodeInstance): void => {
+  if (node.parentId === undefined) {
+    removeOrderedId(document.nodes.rootNodeIds, node.id);
+    return;
+  }
+  const parentNode = document.nodes.byId.get(node.parentId);
+  if (!parentNode) {
+    return;
+  }
+  removeOrderedId(parentNode.childIds, node.id);
+};
+
+const attachNodeInstance = (
+  document: SceneDocument,
+  node: SceneDocumentNodeInstance,
+  parentId: string | undefined,
+  index?: number,
+): void => {
+  node.parentId = parentId;
+  if (parentId === undefined) {
+    insertOrderedId(document.nodes.rootNodeIds, node.id, index);
+    return;
+  }
+  const parentNode = document.nodes.byId.get(parentId);
+  if (!parentNode) {
+    throw new Error(`scene document parent node "${parentId}" does not exist`);
+  }
+  insertOrderedId(parentNode.childIds, node.id, index);
+};
+
+export const createSceneDocument = (id = 'scene'): SceneDocument => ({
+  scene: { id },
+  assets: createResourceCollection(),
+  textures: createResourceCollection(),
+  materials: createResourceCollection(),
+  lights: createResourceCollection(),
+  meshes: createResourceCollection(),
+  cameras: createResourceCollection(),
+  nodes: {
+    order: [],
+    rootNodeIds: [],
+    byId: new Map<string, SceneDocumentNodeInstance>(),
+  },
+});
+
+export const applySceneDocumentScene = (
+  document: SceneDocument,
+  scene: Readonly<{
+    id: string;
+    activeCameraId?: string;
+  }>,
+): SceneDocument => {
+  document.scene.id = scene.id;
+  document.scene.activeCameraId = scene.activeCameraId;
+  return document;
+};
+
+export const upsertSceneDocumentResource = <TKind extends SceneDocumentResourceKind>(
+  document: SceneDocument,
+  input: SceneDocumentResourceInput<TKind>,
+): SceneDocumentResourceInstance<TKind> => {
+  const collection = getResourceCollection(document, input.kind);
+  const existing = collection.byId.get(input.value.id);
+  if (existing) {
+    existing.value = input.value;
+    return existing;
+  }
+
+  const instance = {
+    kind: input.kind,
+    id: input.value.id,
+    value: input.value,
+  } satisfies SceneDocumentResourceInstance<TKind>;
+  collection.byId.set(instance.id, instance);
+  collection.order.push(instance.id);
+  return instance;
+};
+
+export const removeSceneDocumentResource = <TKind extends SceneDocumentResourceKind>(
+  document: SceneDocument,
+  kind: TKind,
+  id: string,
+): boolean => {
+  const collection = getResourceCollection(document, kind);
+  if (!collection.byId.delete(id)) {
+    return false;
+  }
+  removeOrderedId(collection.order, id);
+  return true;
+};
+
+export const upsertSceneDocumentNode = (
+  document: SceneDocument,
+  input: SceneDocumentNodeInput,
+): SceneDocumentNodeInstance => {
+  const existing = document.nodes.byId.get(input.id);
+  if (existing) {
+    if (existing.parentId !== input.parentId) {
+      detachNodeInstance(document, existing);
+      attachNodeInstance(document, existing, input.parentId, input.index);
+    } else if (input.parentId === undefined) {
+      insertOrderedId(document.nodes.rootNodeIds, existing.id, input.index);
+    } else {
+      const parentNode = document.nodes.byId.get(input.parentId);
+      if (!parentNode) {
+        throw new Error(`scene document parent node "${input.parentId}" does not exist`);
+      }
+      insertOrderedId(parentNode.childIds, existing.id, input.index);
+    }
+    existing.props = input.props ?? {};
+    return existing;
+  }
+
+  const instance: SceneDocumentNodeInstance = {
+    kind: 'node',
+    id: input.id,
+    parentId: undefined,
+    childIds: [],
+    props: input.props ?? {},
+  };
+  document.nodes.byId.set(instance.id, instance);
+  document.nodes.order.push(instance.id);
+  attachNodeInstance(document, instance, input.parentId, input.index);
+  return instance;
+};
+
+export const removeSceneDocumentNode = (document: SceneDocument, id: string): boolean => {
+  const node = document.nodes.byId.get(id);
+  if (!node) {
+    return false;
+  }
+
+  for (const childId of [...node.childIds]) {
+    removeSceneDocumentNode(document, childId);
+  }
+
+  detachNodeInstance(document, node);
+  document.nodes.byId.delete(id);
+  removeOrderedId(document.nodes.order, id);
+  return true;
+};
+
+export const sceneDocumentToSceneIr = (document: SceneDocument): SceneIr => {
+  let scene = document.scene.activeCameraId === undefined ? createSceneIr(document.scene.id) : {
+    ...createSceneIr(document.scene.id),
+    activeCameraId: document.scene.activeCameraId,
+  };
+
+  for (const id of document.assets.order) {
+    const asset = document.assets.byId.get(id);
+    if (asset) {
+      scene = appendAsset(scene, asset.value);
+    }
+  }
+  for (const id of document.textures.order) {
+    const texture = document.textures.byId.get(id);
+    if (texture) {
+      scene = appendTexture(scene, texture.value);
+    }
+  }
+  for (const id of document.materials.order) {
+    const material = document.materials.byId.get(id);
+    if (material) {
+      scene = appendMaterial(scene, material.value);
+    }
+  }
+  for (const id of document.lights.order) {
+    const light = document.lights.byId.get(id);
+    if (light) {
+      scene = appendLight(scene, light.value);
+    }
+  }
+  for (const id of document.meshes.order) {
+    const mesh = document.meshes.byId.get(id);
+    if (mesh) {
+      scene = appendMesh(scene, mesh.value);
+    }
+  }
+  for (const id of document.cameras.order) {
+    const camera = document.cameras.byId.get(id);
+    if (camera) {
+      scene = appendCamera(scene, camera.value);
+    }
+  }
+  for (const id of document.nodes.order) {
+    const node = document.nodes.byId.get(id);
+    if (node) {
+      scene = appendNode(
+        scene,
+        createNode(node.id, {
+          parentId: node.parentId,
+          ...node.props,
+        }),
+      );
+    }
+  }
+
+  return scene;
+};

--- a/packages/react/src/scene_root.ts
+++ b/packages/react/src/scene_root.ts
@@ -1,6 +1,11 @@
 import type { Node, SceneIr } from '@rieul3d/ir';
 
-import { type AuthoringElement, authoringTreeToSceneIr } from './authoring.ts';
+import { type AuthoringElement, authoringTreeToSceneDocument } from './authoring.ts';
+import {
+  createSceneDocument,
+  type SceneDocument,
+  sceneDocumentToSceneIr,
+} from './scene_document.ts';
 
 type SceneRootEntityWithId = Readonly<{ id: string }>;
 
@@ -367,11 +372,16 @@ export const commitSummaryNeedsResidencyReset = (summary: SceneRootCommitSummary
 
 export const createSceneRoot = (initialElement?: AuthoringElement): SceneRoot => {
   let currentScene: SceneIr | undefined;
+  let currentDocument: SceneDocument | undefined;
   let revision = 0;
   const subscribers = new Set<SceneRootSubscriber>();
 
   const render = (element: AuthoringElement): SceneIr => {
-    const scene = authoringTreeToSceneIr(element);
+    if (currentDocument === undefined) {
+      currentDocument = createSceneDocument(element.id);
+    }
+    authoringTreeToSceneDocument(element, currentDocument);
+    const scene = sceneDocumentToSceneIr(currentDocument);
     const commit = {
       scene,
       previousScene: currentScene,

--- a/tests/react_authoring_test.tsx
+++ b/tests/react_authoring_test.tsx
@@ -15,6 +15,13 @@ import {
   planSceneRootCommitUpdates,
   summarizeSceneRootCommit,
 } from '@rieul3d/react';
+import {
+  createSceneDocument,
+  removeSceneDocumentNode,
+  sceneDocumentToSceneIr,
+  upsertSceneDocumentNode,
+} from '../packages/react/src/scene_document.ts';
+import { authoringTreeToSceneDocument } from '../packages/react/src/authoring.ts';
 
 Deno.test('authoringTreeToSceneIr lowers declarative nodes into scene ir', () => {
   const scene = authoringTreeToSceneIr(
@@ -528,6 +535,117 @@ Deno.test('createSceneRoot publishes committed scene snapshots', () => {
   ]);
 });
 
+Deno.test('authoringTreeToSceneDocument reuses stable node and resource instances across renders', () => {
+  const document = createSceneDocument('jsx-scene');
+
+  authoringTreeToSceneDocument(
+    <scene id='jsx-scene' activeCameraId='camera-main'>
+      <PerspectiveCamera id='camera-main' position={[0, 0, 2]} />
+      <group id='root'>
+        <node id='mesh-node' name='Before' />
+      </group>
+    </scene>,
+    document,
+  );
+
+  const firstCamera = document.cameras.byId.get('camera-main');
+  const firstRoot = document.nodes.byId.get('root');
+  const firstMeshNode = document.nodes.byId.get('mesh-node');
+
+  authoringTreeToSceneDocument(
+    <scene id='jsx-scene' activeCameraId='camera-main'>
+      <PerspectiveCamera id='camera-main' position={[1, 2, 3]} />
+      <group id='root' position={[4, 5, 6]}>
+        <node id='mesh-node' name='After' />
+      </group>
+    </scene>,
+    document,
+  );
+
+  assertEquals(document.cameras.byId.get('camera-main') === firstCamera, true);
+  assertEquals(document.nodes.byId.get('root') === firstRoot, true);
+  assertEquals(document.nodes.byId.get('mesh-node') === firstMeshNode, true);
+  assertEquals(document.nodes.byId.get('root')?.props.transform, {
+    translation: { x: 4, y: 5, z: 6 },
+    rotation: { x: 0, y: 0, z: 0, w: 1 },
+    scale: { x: 1, y: 1, z: 1 },
+  });
+  assertEquals(document.nodes.byId.get('mesh-node')?.props.name, 'After');
+});
+
+Deno.test('authoringTreeToSceneDocument removes stale resources and node subtrees', () => {
+  const document = createSceneDocument('jsx-scene');
+
+  authoringTreeToSceneDocument(
+    <scene id='jsx-scene'>
+      <mesh
+        id='triangle'
+        attributes={[{
+          semantic: 'POSITION',
+          itemSize: 3,
+          values: [0, 0.7, 0, -0.7, -0.7, 0, 0.7, -0.7, 0],
+        }]}
+      />
+      <group id='root'>
+        <node id='parent'>
+          <node id='child' meshId='triangle' />
+        </node>
+      </group>
+    </scene>,
+    document,
+  );
+
+  authoringTreeToSceneDocument(
+    <scene id='jsx-scene'>
+      <group id='root' />
+    </scene>,
+    document,
+  );
+
+  assertEquals(document.meshes.order, []);
+  assertEquals(document.nodes.order, ['root']);
+  assertEquals(document.nodes.byId.has('parent'), false);
+  assertEquals(document.nodes.byId.has('child'), false);
+});
+
+Deno.test('scene document helpers preserve node identity through reparenting and recursive removal', () => {
+  const document = createSceneDocument('scene-doc');
+
+  upsertSceneDocumentNode(document, { id: 'parent-a', index: 0 });
+  upsertSceneDocumentNode(document, { id: 'parent-b', index: 1 });
+  const child = upsertSceneDocumentNode(document, {
+    id: 'child',
+    parentId: 'parent-a',
+    index: 0,
+    props: { name: 'Child' },
+  });
+  upsertSceneDocumentNode(document, {
+    id: 'grandchild',
+    parentId: 'child',
+    index: 0,
+  });
+
+  upsertSceneDocumentNode(document, {
+    id: 'child',
+    parentId: 'parent-b',
+    index: 0,
+    props: { name: 'Child Moved' },
+  });
+
+  assertEquals(document.nodes.byId.get('child') === child, true);
+  assertEquals(document.nodes.byId.get('parent-a')?.childIds, []);
+  assertEquals(document.nodes.byId.get('parent-b')?.childIds, ['child']);
+  assertEquals(document.nodes.byId.get('child')?.props.name, 'Child Moved');
+
+  removeSceneDocumentNode(document, 'parent-b');
+
+  assertEquals(document.nodes.rootNodeIds, ['parent-a']);
+  assertEquals(document.nodes.byId.has('parent-b'), false);
+  assertEquals(document.nodes.byId.has('child'), false);
+  assertEquals(document.nodes.byId.has('grandchild'), false);
+  assertEquals(sceneDocumentToSceneIr(document).nodes.map((node) => node.id), ['parent-a']);
+});
+
 Deno.test('summarizeSceneRootCommit reports first-commit additions', () => {
   const root = createSceneRoot();
   let summary:
@@ -833,8 +951,8 @@ Deno.test('planSceneRootCommitUpdates classifies node mutations by update kind',
     unchangedIds: [
       'scene-root',
       'parent-a',
-      'parent-b',
       'reparent-child',
+      'parent-b',
       'transform-child',
     ],
     transformIds: [


### PR DESCRIPTION
## Summary
- add a package-local React scene document that preserves stable resource and node host instances
- route createSceneRoot() through the scene document before publishing data-only SceneIr snapshots
- document the new reconciler waypoint and add coverage for identity reuse, reparenting, and removal flows

## Testing
- deno test --unstable-raw-imports tests/react_authoring_test.tsx
- deno task docs:check

## Related
- closes #117
- refs #112