### PR TITLE
procedural: expand noise and generator coverage

### DIFF
--- a/docs/specs/procedural-generation.md
+++ b/docs/specs/procedural-generation.md
@@ -13,14 +13,17 @@ patterns, 2D textures, and 3D volumes without depending on checked-in source ass
 ## Current Coverage
 
 - scalar sampling: value noise in 2D and 3D
-- fractal helpers: fBm and turbulence built on top of value noise
-- 2D generators: checkerboard, linear gradient, UV debug, and grayscale noise textures
-- 3D generators: grayscale noise volumes
+- cellular sampling: Worley noise in 2D and 3D
+- fractal helpers: fBm, turbulence, ridged noise, and domain-warped fBm built on top of the reusable
+  scalar samplers
+- 2D generators: checkerboard, linear gradient, UV debug, grayscale noise, Worley, and color
+  domain-warped noise textures
+- 3D generators: grayscale noise, Worley, and domain-warped noise volumes
 
 ## Constraints
 
 - generators return plain typed-array payloads plus explicit dimensions and channel counts
 - deterministic seeds should produce byte-identical output across repeated calls in the same runtime
 - the math layer must remain reusable without forcing callers through a baked texture API
-- richer noise families such as Perlin, Simplex, Worley, and domain warping can extend the same
-  shape later without breaking current callers
+- richer gradient-noise families such as Perlin and Simplex can extend the same shape later without
+  breaking current callers

--- a/packages/procedural/src/math.ts
+++ b/packages/procedural/src/math.ts
@@ -2,6 +2,8 @@ const defaultOctaves = 4;
 const defaultLacunarity = 2;
 const defaultGain = 0.5;
 const defaultFrequency = 1;
+const sqrt2 = Math.sqrt(2);
+const sqrt3 = Math.sqrt(3);
 
 export type NoiseOptions = Readonly<{
   seed?: number;
@@ -48,6 +50,26 @@ const sampleLattice2d = (x: number, y: number, seed: number): number => hash(see
 
 const sampleLattice3d = (x: number, y: number, z: number, seed: number): number =>
   hash(seed, x, y, z);
+
+const sampleFeaturePoint2d = (
+  x: number,
+  y: number,
+  seed: number,
+): readonly [number, number] => [
+  x + sampleLattice2d(x, y, seed),
+  y + sampleLattice2d(x, y, seed + 1),
+];
+
+const sampleFeaturePoint3d = (
+  x: number,
+  y: number,
+  z: number,
+  seed: number,
+): readonly [number, number, number] => [
+  x + sampleLattice3d(x, y, z, seed),
+  y + sampleLattice3d(x, y, z, seed + 1),
+  z + sampleLattice3d(x, y, z, seed + 2),
+];
 
 const noiseSeed = (options: NoiseOptions): number => assertFiniteNumber('seed', options.seed ?? 0);
 
@@ -211,4 +233,141 @@ export const sampleTurbulence3d = (
   }
 
   return weight === 0 ? 0 : clamp01(total / weight);
+};
+
+export const sampleRidgedNoise2d = (
+  x: number,
+  y: number,
+  options: FractalNoiseOptions = {},
+): number => {
+  const { octaves, lacunarity, gain, frequency, seed } = fractalWeights(options);
+  let amplitude = 1;
+  let total = 0;
+  let weight = 0;
+  let currentFrequency = frequency;
+
+  for (let octave = 0; octave < octaves; octave += 1) {
+    const centered = (sampleValueNoise2d(x * currentFrequency, y * currentFrequency, {
+      seed: seed + octave,
+    }) * 2) - 1;
+    total += (1 - Math.abs(centered)) * amplitude;
+    weight += amplitude;
+    amplitude *= gain;
+    currentFrequency *= lacunarity;
+  }
+
+  return weight === 0 ? 0 : clamp01(total / weight);
+};
+
+export const sampleRidgedNoise3d = (
+  x: number,
+  y: number,
+  z: number,
+  options: FractalNoiseOptions = {},
+): number => {
+  const { octaves, lacunarity, gain, frequency, seed } = fractalWeights(options);
+  let amplitude = 1;
+  let total = 0;
+  let weight = 0;
+  let currentFrequency = frequency;
+
+  for (let octave = 0; octave < octaves; octave += 1) {
+    const centered =
+      (sampleValueNoise3d(x * currentFrequency, y * currentFrequency, z * currentFrequency, {
+        seed: seed + octave,
+      }) * 2) - 1;
+    total += (1 - Math.abs(centered)) * amplitude;
+    weight += amplitude;
+    amplitude *= gain;
+    currentFrequency *= lacunarity;
+  }
+
+  return weight === 0 ? 0 : clamp01(total / weight);
+};
+
+export const sampleWorleyNoise2d = (
+  x: number,
+  y: number,
+  options: NoiseOptions = {},
+): number => {
+  const seed = noiseSeed(options);
+  const cellX = Math.floor(x);
+  const cellY = Math.floor(y);
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (let offsetY = -1; offsetY <= 1; offsetY += 1) {
+    for (let offsetX = -1; offsetX <= 1; offsetX += 1) {
+      const [featureX, featureY] = sampleFeaturePoint2d(cellX + offsetX, cellY + offsetY, seed);
+      const dx = featureX - x;
+      const dy = featureY - y;
+      nearestDistance = Math.min(nearestDistance, Math.hypot(dx, dy));
+    }
+  }
+
+  return clamp01(nearestDistance / sqrt2);
+};
+
+export const sampleWorleyNoise3d = (
+  x: number,
+  y: number,
+  z: number,
+  options: NoiseOptions = {},
+): number => {
+  const seed = noiseSeed(options);
+  const cellX = Math.floor(x);
+  const cellY = Math.floor(y);
+  const cellZ = Math.floor(z);
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (let offsetZ = -1; offsetZ <= 1; offsetZ += 1) {
+    for (let offsetY = -1; offsetY <= 1; offsetY += 1) {
+      for (let offsetX = -1; offsetX <= 1; offsetX += 1) {
+        const [featureX, featureY, featureZ] = sampleFeaturePoint3d(
+          cellX + offsetX,
+          cellY + offsetY,
+          cellZ + offsetZ,
+          seed,
+        );
+        const dx = featureX - x;
+        const dy = featureY - y;
+        const dz = featureZ - z;
+        nearestDistance = Math.min(nearestDistance, Math.hypot(dx, dy, dz));
+      }
+    }
+  }
+
+  return clamp01(nearestDistance / sqrt3);
+};
+
+export const sampleDomainWarpedFbm2d = (
+  x: number,
+  y: number,
+  options: FractalNoiseOptions & Readonly<{ warpAmplitude?: number }> = {},
+): number => {
+  const warpAmplitude = assertFiniteNumber('warpAmplitude', options.warpAmplitude ?? 0.35);
+  const seed = noiseSeed(options);
+  const warpX = (sampleValueNoise2d(x + 17.13, y - 9.41, { seed: seed + 101 }) * 2) - 1;
+  const warpY = (sampleValueNoise2d(x - 5.27, y + 13.73, { seed: seed + 211 }) * 2) - 1;
+
+  return sampleFbm2d(x + (warpX * warpAmplitude), y + (warpY * warpAmplitude), options);
+};
+
+export const sampleDomainWarpedFbm3d = (
+  x: number,
+  y: number,
+  z: number,
+  options: FractalNoiseOptions & Readonly<{ warpAmplitude?: number }> = {},
+): number => {
+  const warpAmplitude = assertFiniteNumber('warpAmplitude', options.warpAmplitude ?? 0.35);
+  const seed = noiseSeed(options);
+  const warpX = (sampleValueNoise3d(x + 17.13, y - 9.41, z + 4.2, { seed: seed + 101 }) * 2) - 1;
+  const warpY = (sampleValueNoise3d(x - 5.27, y + 13.73, z - 8.6, { seed: seed + 211 }) * 2) - 1;
+  const warpZ = (sampleValueNoise3d(x + 2.91, y - 7.11, z + 19.4, { seed: seed + 307 }) * 2) - 1;
+
+  return sampleFbm3d(
+    x + (warpX * warpAmplitude),
+    y + (warpY * warpAmplitude),
+    z + (warpZ * warpAmplitude),
+    options,
+  );
 };

--- a/packages/procedural/src/textures.ts
+++ b/packages/procedural/src/textures.ts
@@ -1,4 +1,4 @@
-import { sampleFbm2d } from './math.ts';
+import { sampleDomainWarpedFbm2d, sampleFbm2d, sampleWorleyNoise2d } from './math.ts';
 
 export type ColorRgba = readonly [number, number, number, number];
 
@@ -34,12 +34,33 @@ export type NoiseTextureOptions = Readonly<{
   octaves?: number;
 }>;
 
+export type WorleyTextureOptions = NoiseTextureOptions;
+
+export type ColorNoiseTextureOptions = Readonly<{
+  width: number;
+  height: number;
+  seed?: number;
+  frequency?: number;
+  octaves?: number;
+  warpAmplitude?: number;
+  lowColor?: ColorRgba;
+  highColor?: ColorRgba;
+}>;
+
 const defaultColorA: ColorRgba = [32, 32, 32, 255];
 const defaultColorB: ColorRgba = [224, 224, 224, 255];
 
 const assertDimension = (name: string, value: number): number => {
   if (!Number.isInteger(value) || value <= 0) {
     throw new Error(`"${name}" must be a positive integer`);
+  }
+
+  return value;
+};
+
+const assertFiniteNumber = (name: string, value: number): number => {
+  if (!Number.isFinite(value)) {
+    throw new Error(`"${name}" must be a finite number`);
   }
 
   return value;
@@ -131,7 +152,7 @@ export const createNoiseTexture = (options: NoiseTextureOptions): ProceduralText
   const width = assertDimension('width', options.width);
   const height = assertDimension('height', options.height);
   const data = createTextureData(width, height);
-  const frequency = options.frequency ?? 4;
+  const frequency = assertFiniteNumber('frequency', options.frequency ?? 4);
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
@@ -145,6 +166,56 @@ export const createNoiseTexture = (options: NoiseTextureOptions): ProceduralText
       });
       const value = Math.round(sample * 255);
       writePixel(data, offset, [value, value, value, 255]);
+    }
+  }
+
+  return { width, height, channels: 4, data };
+};
+
+export const createWorleyTexture = (options: WorleyTextureOptions): ProceduralTexture2d => {
+  const width = assertDimension('width', options.width);
+  const height = assertDimension('height', options.height);
+  const data = createTextureData(width, height);
+  const frequency = assertFiniteNumber('frequency', options.frequency ?? 4);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const offset = ((y * width) + x) * 4;
+      const u = width === 1 ? 0 : x / (width - 1);
+      const v = height === 1 ? 0 : y / (height - 1);
+      const sample = sampleWorleyNoise2d(u * frequency, v * frequency, {
+        seed: options.seed,
+      });
+      const value = Math.round((1 - sample) * 255);
+      writePixel(data, offset, [value, value, value, 255]);
+    }
+  }
+
+  return { width, height, channels: 4, data };
+};
+
+export const createColorNoiseTexture = (
+  options: ColorNoiseTextureOptions,
+): ProceduralTexture2d => {
+  const width = assertDimension('width', options.width);
+  const height = assertDimension('height', options.height);
+  const data = createTextureData(width, height);
+  const frequency = assertFiniteNumber('frequency', options.frequency ?? 4);
+  const lowColor = options.lowColor ?? [24, 52, 96, 255];
+  const highColor = options.highColor ?? [236, 246, 255, 255];
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const offset = ((y * width) + x) * 4;
+      const u = width === 1 ? 0 : x / (width - 1);
+      const v = height === 1 ? 0 : y / (height - 1);
+      const sample = sampleDomainWarpedFbm2d(u * frequency, v * frequency, {
+        seed: options.seed,
+        octaves: options.octaves,
+        frequency,
+        warpAmplitude: options.warpAmplitude,
+      });
+      writePixel(data, offset, lerpColor(lowColor, highColor, sample));
     }
   }
 

--- a/packages/procedural/src/volumes.ts
+++ b/packages/procedural/src/volumes.ts
@@ -1,4 +1,4 @@
-import { sampleFbm3d } from './math.ts';
+import { sampleDomainWarpedFbm3d, sampleFbm3d, sampleWorleyNoise3d } from './math.ts';
 
 export type ProceduralVolume3d = Readonly<{
   width: number;
@@ -17,9 +17,25 @@ export type NoiseVolumeOptions = Readonly<{
   octaves?: number;
 }>;
 
+export type WorleyVolumeOptions = NoiseVolumeOptions;
+
+export type DomainWarpedNoiseVolumeOptions =
+  & NoiseVolumeOptions
+  & Readonly<{
+    warpAmplitude?: number;
+  }>;
+
 const assertDimension = (name: string, value: number): number => {
   if (!Number.isInteger(value) || value <= 0) {
     throw new Error(`"${name}" must be a positive integer`);
+  }
+
+  return value;
+};
+
+const assertFiniteNumber = (name: string, value: number): number => {
+  if (!Number.isFinite(value)) {
+    throw new Error(`"${name}" must be a finite number`);
   }
 
   return value;
@@ -29,7 +45,7 @@ export const createNoiseVolume = (options: NoiseVolumeOptions): ProceduralVolume
   const width = assertDimension('width', options.width);
   const height = assertDimension('height', options.height);
   const depth = assertDimension('depth', options.depth);
-  const frequency = options.frequency ?? 3;
+  const frequency = assertFiniteNumber('frequency', options.frequency ?? 3);
   const data = new Uint8Array(width * height * depth);
 
   for (let z = 0; z < depth; z += 1) {
@@ -42,6 +58,59 @@ export const createNoiseVolume = (options: NoiseVolumeOptions): ProceduralVolume
           seed: options.seed,
           octaves: options.octaves,
           frequency,
+        });
+        data[(z * width * height) + (y * width) + x] = Math.round(sample * 255);
+      }
+    }
+  }
+
+  return { width, height, depth, channels: 1, data };
+};
+
+export const createWorleyVolume = (options: WorleyVolumeOptions): ProceduralVolume3d => {
+  const width = assertDimension('width', options.width);
+  const height = assertDimension('height', options.height);
+  const depth = assertDimension('depth', options.depth);
+  const frequency = assertFiniteNumber('frequency', options.frequency ?? 3);
+  const data = new Uint8Array(width * height * depth);
+
+  for (let z = 0; z < depth; z += 1) {
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const u = width === 1 ? 0 : x / (width - 1);
+        const v = height === 1 ? 0 : y / (height - 1);
+        const w = depth === 1 ? 0 : z / (depth - 1);
+        const sample = sampleWorleyNoise3d(u * frequency, v * frequency, w * frequency, {
+          seed: options.seed,
+        });
+        data[(z * width * height) + (y * width) + x] = Math.round((1 - sample) * 255);
+      }
+    }
+  }
+
+  return { width, height, depth, channels: 1, data };
+};
+
+export const createDomainWarpedNoiseVolume = (
+  options: DomainWarpedNoiseVolumeOptions,
+): ProceduralVolume3d => {
+  const width = assertDimension('width', options.width);
+  const height = assertDimension('height', options.height);
+  const depth = assertDimension('depth', options.depth);
+  const frequency = assertFiniteNumber('frequency', options.frequency ?? 3);
+  const data = new Uint8Array(width * height * depth);
+
+  for (let z = 0; z < depth; z += 1) {
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const u = width === 1 ? 0 : x / (width - 1);
+        const v = height === 1 ? 0 : y / (height - 1);
+        const w = depth === 1 ? 0 : z / (depth - 1);
+        const sample = sampleDomainWarpedFbm3d(u * frequency, v * frequency, w * frequency, {
+          seed: options.seed,
+          octaves: options.octaves,
+          frequency,
+          warpAmplitude: options.warpAmplitude,
         });
         data[(z * width * height) + (y * width) + x] = Math.round(sample * 255);
       }

--- a/tests/procedural_test.ts
+++ b/tests/procedural_test.ts
@@ -1,16 +1,26 @@
 import { assert, assertEquals, assertNotEquals, assertThrows } from 'jsr:@std/assert@^1.0.14';
 import {
   createCheckerboardTexture,
+  createColorNoiseTexture,
+  createDomainWarpedNoiseVolume,
   createGradientTexture,
   createNoiseTexture,
   createNoiseVolume,
   createUvDebugTexture,
+  createWorleyTexture,
+  createWorleyVolume,
+  sampleDomainWarpedFbm2d,
+  sampleDomainWarpedFbm3d,
   sampleFbm2d,
   sampleFbm3d,
+  sampleRidgedNoise2d,
+  sampleRidgedNoise3d,
   sampleTurbulence2d,
   sampleTurbulence3d,
   sampleValueNoise2d,
   sampleValueNoise3d,
+  sampleWorleyNoise2d,
+  sampleWorleyNoise3d,
 } from '@rieul3d/procedural';
 
 const assertByteRange = (values: Uint8Array): void => {
@@ -41,11 +51,45 @@ Deno.test('fractal samplers stay normalized', () => {
     sampleTurbulence2d(0.3, 0.4, { seed: 2, octaves: 5 }),
     sampleFbm3d(0.1, 0.2, 0.3, { seed: 2, octaves: 5 }),
     sampleTurbulence3d(0.3, 0.4, 0.5, { seed: 2, octaves: 5 }),
+    sampleRidgedNoise2d(0.15, 0.25, { seed: 3, octaves: 4 }),
+    sampleRidgedNoise3d(0.15, 0.25, 0.35, { seed: 3, octaves: 4 }),
+    sampleWorleyNoise2d(1.1, 2.2, { seed: 4 }),
+    sampleWorleyNoise3d(1.1, 2.2, 3.3, { seed: 4 }),
+    sampleDomainWarpedFbm2d(0.2, 0.6, { seed: 5, octaves: 3, warpAmplitude: 0.4 }),
+    sampleDomainWarpedFbm3d(0.2, 0.6, 0.8, { seed: 5, octaves: 3, warpAmplitude: 0.4 }),
   ];
 
   for (const sample of samples) {
     assert(sample >= 0 && sample <= 1);
   }
+});
+
+Deno.test('extended procedural samplers stay deterministic and react to seeds', () => {
+  assertEquals(
+    sampleRidgedNoise2d(0.4, 0.8, { seed: 12 }),
+    sampleRidgedNoise2d(0.4, 0.8, { seed: 12 }),
+  );
+  assertEquals(
+    sampleWorleyNoise3d(1.5, 2.5, 3.5, { seed: 9 }),
+    sampleWorleyNoise3d(1.5, 2.5, 3.5, { seed: 9 }),
+  );
+  assertEquals(
+    sampleDomainWarpedFbm2d(0.25, 0.75, { seed: 2, warpAmplitude: 0.5 }),
+    sampleDomainWarpedFbm2d(0.25, 0.75, { seed: 2, warpAmplitude: 0.5 }),
+  );
+
+  assertNotEquals(
+    sampleRidgedNoise3d(0.4, 0.8, 1.2, { seed: 12 }),
+    sampleRidgedNoise3d(0.4, 0.8, 1.2, { seed: 13 }),
+  );
+  assertNotEquals(
+    sampleWorleyNoise2d(1.5, 2.5, { seed: 9 }),
+    sampleWorleyNoise2d(1.5, 2.5, { seed: 10 }),
+  );
+  assertNotEquals(
+    sampleDomainWarpedFbm3d(0.25, 0.75, 0.5, { seed: 2, warpAmplitude: 0.5 }),
+    sampleDomainWarpedFbm3d(0.25, 0.75, 0.5, { seed: 3, warpAmplitude: 0.5 }),
+  );
 });
 
 Deno.test('checkerboard, gradient, and uv textures expose stable dimensions and pixels', () => {
@@ -105,6 +149,66 @@ Deno.test('noise texture and volume stay deterministic with valid ranges', () =>
   assertByteRange(volume.data);
 });
 
+Deno.test('extended procedural generators expose stable output ranges', () => {
+  const worleyTexture = createWorleyTexture({
+    width: 8,
+    height: 8,
+    seed: 6,
+    frequency: 5,
+  });
+  const colorTexture = createColorNoiseTexture({
+    width: 4,
+    height: 4,
+    seed: 7,
+    octaves: 4,
+    frequency: 3,
+    warpAmplitude: 0.45,
+    lowColor: [10, 20, 30, 255],
+    highColor: [200, 210, 220, 255],
+  });
+  const worleyVolume = createWorleyVolume({
+    width: 4,
+    height: 4,
+    depth: 3,
+    seed: 6,
+    frequency: 4,
+  });
+  const warpedVolume = createDomainWarpedNoiseVolume({
+    width: 4,
+    height: 4,
+    depth: 3,
+    seed: 7,
+    octaves: 4,
+    frequency: 3,
+    warpAmplitude: 0.45,
+  });
+
+  assertEquals(worleyTexture.channels, 4);
+  assertEquals(colorTexture.channels, 4);
+  assertEquals(worleyVolume.channels, 1);
+  assertEquals(warpedVolume.channels, 1);
+  assertEquals(
+    worleyTexture.data,
+    createWorleyTexture({ width: 8, height: 8, seed: 6, frequency: 5 }).data,
+  );
+  assertEquals(
+    warpedVolume.data,
+    createDomainWarpedNoiseVolume({
+      width: 4,
+      height: 4,
+      depth: 3,
+      seed: 7,
+      octaves: 4,
+      frequency: 3,
+      warpAmplitude: 0.45,
+    }).data,
+  );
+  assertByteRange(worleyTexture.data);
+  assertByteRange(colorTexture.data);
+  assertByteRange(worleyVolume.data);
+  assertByteRange(warpedVolume.data);
+});
+
 Deno.test('procedural generators reject invalid dimensions', () => {
   assertThrows(() => createCheckerboardTexture({ width: 0, height: 4 }));
   assertThrows(() =>
@@ -118,6 +222,10 @@ Deno.test('procedural generators reject invalid dimensions', () => {
   assertThrows(() => createUvDebugTexture({ width: -1, height: 2 }));
   assertThrows(() => createNoiseTexture({ width: 2, height: 0 }));
   assertThrows(() => createNoiseVolume({ width: 1, height: 1, depth: 0 }));
+  assertThrows(() => createWorleyTexture({ width: 0, height: 2 }));
+  assertThrows(() => createColorNoiseTexture({ width: 2, height: 0 }));
+  assertThrows(() => createWorleyVolume({ width: 1, height: 1, depth: -1 }));
+  assertThrows(() => createDomainWarpedNoiseVolume({ width: 1, height: 1, depth: 0 }));
 });
 
 Deno.test('procedural noise rejects non-finite fractal parameters', () => {
@@ -126,8 +234,21 @@ Deno.test('procedural noise rejects non-finite fractal parameters', () => {
   assertThrows(() => sampleFbm3d(0.1, 0.2, 0.3, { frequency: Number.POSITIVE_INFINITY }));
   assertThrows(() => sampleTurbulence2d(0.1, 0.2, { gain: Number.NaN }));
   assertThrows(() => sampleTurbulence3d(0.1, 0.2, 0.3, { lacunarity: Number.NEGATIVE_INFINITY }));
+  assertThrows(() => sampleRidgedNoise2d(0.1, 0.2, { gain: Number.NaN }));
+  assertThrows(() => sampleWorleyNoise3d(0.1, 0.2, 0.3, { seed: Number.POSITIVE_INFINITY }));
+  assertThrows(() => sampleDomainWarpedFbm2d(0.1, 0.2, { warpAmplitude: Number.NaN }));
   assertThrows(() => createNoiseTexture({ width: 2, height: 2, frequency: Number.NaN }));
+  assertThrows(() => createWorleyTexture({ width: 2, height: 2, frequency: Number.NaN }));
+  assertThrows(() => createColorNoiseTexture({ width: 2, height: 2, warpAmplitude: Number.NaN }));
   assertThrows(() =>
     createNoiseVolume({ width: 2, height: 2, depth: 2, octaves: Number.POSITIVE_INFINITY })
+  );
+  assertThrows(() =>
+    createDomainWarpedNoiseVolume({
+      width: 2,
+      height: 2,
+      depth: 2,
+      warpAmplitude: Number.NaN,
+    })
   );
 });


### PR DESCRIPTION
## Summary
- add Worley, ridged, and domain-warped procedural samplers to @rieul3d/procedural
- add Worley/color-noise textures plus Worley/domain-warped volume generators with input validation
- extend procedural tests and documentation to cover the expanded generator surface

## Testing
- deno test tests/procedural_test.ts
- deno check packages/procedural/mod.ts
- deno task docs:check

## Related
- closes #106
- refs #122