### PR TITLE
Add minimal post-process pass contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Implemented today:
 - mesh, texture, first volume residency upload paths, and first volume raymarch execution
 - forward rendering, minimal deferred mesh execution with built-in unlit/lit plus custom WGSL
   G-buffer paths, deferred directional-light resolve support, optional baseColor texture sampling,
-  post-lighting deferred SDF/volume composition, first-class directional light nodes with built-in
+  post-lighting deferred SDF/volume composition, renderer-owned fullscreen post-process chaining
+  with an initial identity/blit pass contract, first-class directional light nodes with built-in
   forward Lambert shading, first SDF raymarch execution, and headless snapshot readback
 - forward SDF sphere and box raymarch execution with capability preflight alignment
 - built-in unlit material registration, evaluated mesh transform uploads, base-color texture
@@ -62,7 +63,8 @@ Implemented today:
   camera/light composition, and commit-summary plus update-plan helpers for targeted residency
   invalidation without forcing resets for transform-only node changes
 - proposed ADR/discussion tracking for the next React live-update boundary decision around
-  partial-apply scene updates without renderer ownership
+  partial-apply scene updates without renderer ownership, plus the longer-term post-processing
+  execution model after the first shipped fullscreen pass contract
 - fixture-backed golden snapshot regression tests for clear, mesh, sphere/box SDF, volume, and
   recovery rebuild renders, including guards against raymarch fixtures collapsing back to clear-only
   output

--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -17,6 +17,8 @@ The initial renderer uses a lightweight pass graph:
 - explicit resource names
 - explicit dependencies
 - no full frame-graph aliasing or aggressive optimization yet
+- optional renderer-owned fullscreen post-process passes that run between scene-color output and
+  final presentation
 
 ## Primitive Mapping
 
@@ -43,6 +45,9 @@ The initial renderer uses a lightweight pass graph:
 - Forward rendering also encodes a dedicated SDF raymarch pass for supported sphere and box
   primitives.
 - Forward rendering also encodes a first volume raymarch pass for volume primitives with residency.
+- Forward and deferred rendering can now optionally route scene output through ordered fullscreen
+  post-process passes. The initial contract provides a sampled scene-color texture, sampler, and an
+  optional uniform buffer to a fullscreen triangle shader before the final present step.
 - Built-in unlit WGSL is stored as a standalone shader file and imported as text.
 - Built-in forward lit WGSL is stored as a standalone shader file and consumes directional-light
   uniform data extracted from evaluated light nodes.
@@ -71,6 +76,7 @@ The initial renderer uses a lightweight pass graph:
   plus non-textured built-in `lit` materials, with optional base-color textures on `unlit`.
 - Custom WGSL programs can be registered and cached through the material registry.
 - Headless/offscreen rendering supports compact byte readback for snapshot testing.
+- Headless/offscreen snapshots reuse the same optional post-process chain instead of bypassing it.
 - Snapshot bytes can also be encoded into PNG for local inspection and regression workflows.
 - Browser examples cover the minimal mesh-only path, a texture-backed built-in unlit path, and a
   custom WGSL path that samples texture residency through declared material bindings.
@@ -116,6 +122,8 @@ The initial renderer uses a lightweight pass graph:
   `examples/headless_snapshot/out/forward.png`.
 - The workflow reuses `requestGpuContext`, `rebuildRuntimeResidency`, `renderForwardSnapshot`, and
   `encodePngRgba` instead of adding a separate renderer path.
+- When post-process passes are requested, the same offscreen snapshot path reads back the final
+  post-processed color target.
 - The command accepts optional output path, width, and height arguments for ad hoc captures.
 
 ## Known Gaps
@@ -123,3 +131,5 @@ The initial renderer uses a lightweight pass graph:
 - Deferred rendering does not yet support textures on built-in lit materials.
 - SDF execution currently supports sphere and box primitives only; broader graph/operator coverage
   is still pending.
+- The current post-process milestone is intentionally narrow: it supports fullscreen color passes
+  with one input texture, one sampler, and optional uniform data, but not a full frame graph.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -41,6 +41,7 @@ export type PassKind =
   | 'gbuffer'
   | 'lighting'
   | 'mesh'
+  | 'post-process'
   | 'raymarch'
   | 'present';
 
@@ -90,6 +91,18 @@ export type GpuRenderExecutionContext = Readonly<{
     | 'createTexture'
   >;
   queue: Pick<GPUQueue, 'submit' | 'writeBuffer'>;
+}>;
+
+export type PostProcessPass = Readonly<{
+  id: string;
+  label: string;
+  fragmentWgsl: string;
+  fragmentEntryPoint: string;
+  uniformData?: ArrayBufferView;
+}>;
+
+export type RenderFrameOptions = Readonly<{
+  postProcessPasses?: readonly PostProcessPass[];
 }>;
 
 export type ForwardRenderResult = Readonly<{
@@ -199,6 +212,24 @@ export type DirectionalLightItem = Readonly<{
   intensity: number;
 }>;
 
+export const createIdentityPostProcessPass = (
+  id = builtInIdentityPostProcessPassId,
+  label = 'Identity Post-Process',
+): PostProcessPass => ({
+  id,
+  label,
+  fragmentEntryPoint: 'fsMain',
+  fragmentWgsl: `
+@group(0) @binding(0) var postProcessColor: texture_2d<f32>;
+@group(0) @binding(1) var postProcessSampler: sampler;
+
+@fragment
+fn fsMain(in: FullscreenVertexOut) -> @location(0) vec4<f32> {
+  return textureSample(postProcessColor, postProcessSampler, in.uv);
+}
+`,
+});
+
 const builtInUnlitProgramId = 'built-in:unlit';
 const builtInLitProgramId = 'built-in:lit';
 const builtInTexturedUnlitProgramId = 'built-in:unlit-textured';
@@ -209,6 +240,7 @@ const builtInDeferredGbufferLitProgramId = 'built-in:deferred-gbuffer-lit';
 const builtInDeferredLightingProgramId = 'built-in:deferred-lighting';
 const builtInSdfRaymarchProgramId = 'built-in:sdf-raymarch';
 const builtInVolumeRaymarchProgramId = 'built-in:volume-raymarch';
+const builtInIdentityPostProcessPassId = 'built-in:post-process-identity';
 const textureBindingUsage = 0x04;
 const renderAttachmentUsage = 0x10;
 const uniformUsage = 0x40;
@@ -218,6 +250,27 @@ const maxSdfPassItems = 16;
 const depthTextureFormat = 'depth24plus';
 const maxDirectionalLights = 4;
 const defaultAmbientLight = 0.2;
+const fullscreenPostProcessVertexShader = `
+struct FullscreenVertexOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vsMain(@builtin(vertex_index) vertexIndex: u32) -> FullscreenVertexOut {
+  var positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -3.0),
+    vec2<f32>(-1.0, 1.0),
+    vec2<f32>(3.0, 1.0),
+  );
+  let position = positions[vertexIndex];
+
+  var out: FullscreenVertexOut;
+  out.position = vec4<f32>(position, 0.0, 1.0);
+  out.uv = (position * vec2<f32>(0.5, -0.5)) + vec2<f32>(0.5, 0.5);
+  return out;
+}
+`;
 const toBufferSource = (view: ArrayBufferView): Uint8Array<ArrayBuffer> => {
   const buffer = view.buffer.slice(
     view.byteOffset,
@@ -725,8 +778,27 @@ export const planFrame = (
   renderer: Renderer,
   evaluatedScene: EvaluatedScene,
   _residency: RuntimeResidency,
+  options: RenderFrameOptions = {},
 ): FramePlan => {
   const counts = countPrimitiveNodes(evaluatedScene);
+  const postProcessPasses = options.postProcessPasses ?? [];
+  const passes = renderer.passes.filter((pass) =>
+    pass.kind === 'raymarch' ? counts.sdfNodeCount > 0 || counts.volumeNodeCount > 0 : true
+  );
+  const presentIndex = passes.findIndex((pass) => pass.kind === 'present');
+
+  if (postProcessPasses.length > 0 && presentIndex >= 0) {
+    passes.splice(
+      presentIndex,
+      0,
+      ...postProcessPasses.map((pass, index) => ({
+        id: pass.id,
+        kind: 'post-process' as const,
+        reads: [index === 0 ? 'color' : `post-process:${postProcessPasses[index - 1]?.id}`],
+        writes: [`post-process:${pass.id}`],
+      })),
+    );
+  }
 
   return {
     renderer: renderer.kind,
@@ -734,9 +806,7 @@ export const planFrame = (
     meshNodeCount: counts.meshNodeCount,
     sdfNodeCount: counts.sdfNodeCount,
     volumeNodeCount: counts.volumeNodeCount,
-    passes: renderer.passes.filter((pass) =>
-      pass.kind === 'raymarch' ? counts.sdfNodeCount > 0 || counts.volumeNodeCount > 0 : true
-    ),
+    passes,
   };
 };
 
@@ -1205,6 +1275,47 @@ const createDirectionalLightUniformData = (
 const usesLitMaterialProgram = (program: MaterialProgram): boolean =>
   program.id === builtInLitProgramId;
 
+const getPostProcessShaderCode = (pass: PostProcessPass): string =>
+  `${fullscreenPostProcessVertexShader}\n${pass.fragmentWgsl}`;
+
+export const ensurePostProcessPipeline = (
+  context: GpuRenderExecutionContext,
+  residency: RuntimeResidency,
+  pass: PostProcessPass,
+  format: GPUTextureFormat,
+): GPURenderPipeline => {
+  const uniformSuffix = pass.uniformData ? ':uniform' : ':nouniform';
+  const cacheKey = `${pass.id}:${format}${uniformSuffix}`;
+  const cached = residency.pipelines.get(cacheKey);
+  if (cached) {
+    return cached as GPURenderPipeline;
+  }
+
+  const shader = context.device.createShaderModule({
+    label: cacheKey,
+    code: getPostProcessShaderCode(pass),
+  });
+  const pipeline = context.device.createRenderPipeline({
+    label: cacheKey,
+    layout: 'auto',
+    vertex: {
+      module: shader,
+      entryPoint: 'vsMain',
+    },
+    fragment: {
+      module: shader,
+      entryPoint: pass.fragmentEntryPoint,
+      targets: [{ format }],
+    },
+    primitive: {
+      topology: 'triangle-list',
+    },
+  });
+
+  residency.pipelines.set(cacheKey, pipeline);
+  return pipeline;
+};
+
 export const ensureBuiltInForwardPipeline = (
   context: GpuRenderExecutionContext,
   residency: RuntimeResidency,
@@ -1555,6 +1666,7 @@ export const renderSdfRaymarchPass = (
   context: GpuRenderExecutionContext,
   encoder: GPUCommandEncoder,
   binding: RenderContextBinding,
+  targetView: GPUTextureView,
   residency: RuntimeResidency,
   evaluatedScene: EvaluatedScene,
 ): number => {
@@ -1584,7 +1696,7 @@ export const renderSdfRaymarchPass = (
 
   const pass = encoder.beginRenderPass({
     colorAttachments: [{
-      view: acquireColorAttachmentView(binding),
+      view: targetView,
       loadOp: 'load',
       storeOp: 'store',
     }],
@@ -1602,6 +1714,7 @@ export const renderVolumeRaymarchPass = (
   context: GpuRenderExecutionContext,
   encoder: GPUCommandEncoder,
   binding: RenderContextBinding,
+  targetView: GPUTextureView,
   residency: RuntimeResidency,
   evaluatedScene: EvaluatedScene,
 ): number => {
@@ -1613,7 +1726,7 @@ export const renderVolumeRaymarchPass = (
   const pipeline = ensureVolumeRaymarchPipeline(context, residency, binding.target.format);
   const pass = encoder.beginRenderPass({
     colorAttachments: [{
-      view: acquireColorAttachmentView(binding),
+      view: targetView,
       loadOp: 'load',
       storeOp: 'store',
     }],
@@ -1692,6 +1805,7 @@ export const renderForwardFrame = (
   residency: RuntimeResidency,
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
+  options: RenderFrameOptions = {},
 ): ForwardRenderResult => {
   assertRendererSceneCapabilities(
     createForwardRenderer(),
@@ -1699,7 +1813,11 @@ export const renderForwardFrame = (
     materialRegistry,
     residency,
   );
-  const view = acquireColorAttachmentView(binding);
+  const postProcessPasses = getPostProcessPasses(options);
+  const sceneColor = postProcessPasses.length > 0
+    ? createSceneColorResources(context, binding)
+    : undefined;
+  const view = sceneColor?.view ?? acquireColorAttachmentView(binding);
   const viewProjectionMatrix = createViewProjectionMatrix(binding, evaluatedScene.activeCamera);
   const encoder = context.device.createCommandEncoder({
     label: 'forward-frame',
@@ -1845,15 +1963,25 @@ export const renderForwardFrame = (
 
   pass.end();
 
-  drawCount += renderSdfRaymarchPass(context, encoder, binding, residency, evaluatedScene);
-  drawCount += renderVolumeRaymarchPass(context, encoder, binding, residency, evaluatedScene);
+  drawCount += renderSdfRaymarchPass(context, encoder, binding, view, residency, evaluatedScene);
+  drawCount += renderVolumeRaymarchPass(context, encoder, binding, view, residency, evaluatedScene);
 
   const commandBuffer = encoder.finish();
   context.queue.submit([commandBuffer]);
 
+  if (sceneColor) {
+    drawCount += renderPostProcessChain(
+      context,
+      binding,
+      residency,
+      postProcessPasses,
+      sceneColor.texture,
+    );
+  }
+
   return {
     drawCount,
-    submittedCommandBufferCount: 1,
+    submittedCommandBufferCount: 1 + (sceneColor ? 1 : 0),
   };
 };
 
@@ -1876,12 +2004,131 @@ const createTransientRenderTexture = (
     usage,
   });
 
+function getPostProcessPasses(options: RenderFrameOptions): readonly PostProcessPass[] {
+  return options.postProcessPasses ?? [];
+}
+
+function createSceneColorResources(
+  context: GpuRenderExecutionContext,
+  binding: RenderContextBinding,
+): Readonly<{
+  texture: GPUTexture;
+  view: GPUTextureView;
+}> {
+  const texture = createTransientRenderTexture(
+    context,
+    binding,
+    'scene-color',
+    binding.target.format,
+  );
+  return { texture, view: texture.createView() };
+}
+
+function renderPostProcessChain(
+  context: GpuRenderExecutionContext,
+  binding: RenderContextBinding,
+  residency: RuntimeResidency,
+  postProcessPasses: readonly PostProcessPass[],
+  inputTexture: GPUTexture,
+): number {
+  if (postProcessPasses.length === 0) {
+    return 0;
+  }
+
+  const sampler = context.device.createSampler({
+    magFilter: 'linear',
+    minFilter: 'linear',
+  });
+  const encoder = context.device.createCommandEncoder({
+    label: 'post-process-chain',
+  });
+  let currentTexture = inputTexture;
+  let drawCount = 0;
+
+  for (let index = 0; index < postProcessPasses.length; index += 1) {
+    const passDescriptor = postProcessPasses[index];
+    const isLastPass = index === postProcessPasses.length - 1;
+    const outputTexture = isLastPass ? undefined : createTransientRenderTexture(
+      context,
+      binding,
+      `post-process-${passDescriptor.id}`,
+      binding.target.format,
+    );
+    const outputView = outputTexture?.createView() ?? acquireColorAttachmentView(binding);
+    const pipeline = ensurePostProcessPipeline(
+      context,
+      residency,
+      passDescriptor,
+      binding.target.format,
+    );
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [{
+        view: outputView,
+        clearValue: { r: 0, g: 0, b: 0, a: 1 },
+        loadOp: 'clear',
+        storeOp: 'store',
+      }],
+    });
+
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(
+      0,
+      context.device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          {
+            binding: 0,
+            resource: currentTexture.createView(),
+          },
+          {
+            binding: 1,
+            resource: sampler,
+          },
+        ],
+      }),
+    );
+
+    if (passDescriptor.uniformData) {
+      const uniformBuffer = context.device.createBuffer({
+        label: `${passDescriptor.id}:post-process-uniforms`,
+        size: passDescriptor.uniformData.byteLength,
+        usage: uniformUsage | bufferCopyDstUsage,
+      });
+      context.queue.writeBuffer(uniformBuffer, 0, toBufferSource(passDescriptor.uniformData));
+      pass.setBindGroup(
+        1,
+        context.device.createBindGroup({
+          layout: pipeline.getBindGroupLayout(1),
+          entries: [{
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+            },
+          }],
+        }),
+      );
+    }
+
+    pass.draw(3, 1, 0, 0);
+    pass.end();
+    drawCount += 1;
+
+    if (outputTexture) {
+      currentTexture = outputTexture;
+    }
+  }
+
+  context.queue.submit([encoder.finish()]);
+  return drawCount;
+}
+
 export const renderDeferredFrame = (
   context: GpuRenderExecutionContext,
   binding: RenderContextBinding,
   residency: RuntimeResidency,
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
+  options: RenderFrameOptions = {},
 ): DeferredRenderResult => {
   assertRendererSceneCapabilities(
     createDeferredRenderer(),
@@ -1890,6 +2137,11 @@ export const renderDeferredFrame = (
     residency,
   );
 
+  const postProcessPasses = getPostProcessPasses(options);
+  const sceneColor = postProcessPasses.length > 0
+    ? createSceneColorResources(context, binding)
+    : undefined;
+  const finalColorView = sceneColor?.view ?? acquireColorAttachmentView(binding);
   const depthTexture = createTransientRenderTexture(
     context,
     binding,
@@ -2102,7 +2354,7 @@ export const renderDeferredFrame = (
   });
   const lightingPass = encoder.beginRenderPass({
     colorAttachments: [{
-      view: acquireColorAttachmentView(binding),
+      view: finalColorView,
       clearValue: { r: 0.02, g: 0.02, b: 0.03, a: 1 },
       loadOp: 'clear',
       storeOp: 'store',
@@ -2152,15 +2404,39 @@ export const renderDeferredFrame = (
   lightingPass.end();
   drawCount += 1;
 
-  drawCount += renderSdfRaymarchPass(context, encoder, binding, residency, evaluatedScene);
-  drawCount += renderVolumeRaymarchPass(context, encoder, binding, residency, evaluatedScene);
+  drawCount += renderSdfRaymarchPass(
+    context,
+    encoder,
+    binding,
+    finalColorView,
+    residency,
+    evaluatedScene,
+  );
+  drawCount += renderVolumeRaymarchPass(
+    context,
+    encoder,
+    binding,
+    finalColorView,
+    residency,
+    evaluatedScene,
+  );
 
   const commandBuffer = encoder.finish();
   context.queue.submit([commandBuffer]);
 
+  if (sceneColor) {
+    drawCount += renderPostProcessChain(
+      context,
+      binding,
+      residency,
+      postProcessPasses,
+      sceneColor.texture,
+    );
+  }
+
   return {
     drawCount,
-    submittedCommandBufferCount: 1,
+    submittedCommandBufferCount: 1 + (sceneColor ? 1 : 0),
   };
 };
 
@@ -2170,8 +2446,16 @@ export const renderForwardSnapshot = async (
   residency: RuntimeResidency,
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
+  options: RenderFrameOptions = {},
 ): Promise<ForwardSnapshotResult> => {
-  const frame = renderForwardFrame(context, binding, residency, evaluatedScene, materialRegistry);
+  const frame = renderForwardFrame(
+    context,
+    binding,
+    residency,
+    evaluatedScene,
+    materialRegistry,
+    options,
+  );
   const snapshot = await readOffscreenSnapshot(context, binding);
 
   return {
@@ -2188,8 +2472,16 @@ export const renderDeferredSnapshot = async (
   residency: RuntimeResidency,
   evaluatedScene: EvaluatedScene,
   materialRegistry = createMaterialRegistry(),
+  options: RenderFrameOptions = {},
 ): Promise<DeferredSnapshotResult> => {
-  const frame = renderDeferredFrame(context, binding, residency, evaluatedScene, materialRegistry);
+  const frame = renderDeferredFrame(
+    context,
+    binding,
+    residency,
+    evaluatedScene,
+    materialRegistry,
+    options,
+  );
   const snapshot = await readOffscreenSnapshot(context, binding);
 
   return {

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -10,6 +10,7 @@ import {
   createSceneIr,
 } from '@rieul3d/ir';
 import {
+  createIdentityPostProcessPass,
   createMaterialRegistry,
   ensureBuiltInForwardPipeline,
   ensureMaterialPipeline,
@@ -1570,6 +1571,43 @@ Deno.test('renderForwardFrame uploads parented mesh transforms after scene evalu
   assertAlmostEquals(uploadedMatrix[31] ?? 0, 1, 1e-5);
 });
 
+Deno.test('renderForwardFrame runs post-process passes after scene rendering', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMesh(scene, {
+    id: 'mesh-post',
+    attributes: [{ semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] }],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-post' }));
+
+  runtimeResidency.geometry.set('mesh-post', {
+    meshId: 'mesh-post',
+    attributeBuffers: { POSITION: { id: 0 } as unknown as GPUBuffer },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+
+  const result = renderForwardFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    createOffscreenContext({
+      device: mocks.device as unknown as GPUDevice,
+      target: createHeadlessTarget(32, 32),
+    }),
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+    createMaterialRegistry(),
+    {
+      postProcessPasses: [createIdentityPostProcessPass('post:identity')],
+    },
+  );
+
+  assertEquals(result.drawCount, 2);
+  assertEquals(result.submittedCommandBufferCount, 2);
+  assertEquals(mocks.renderPassCount.current, 2);
+  assertEquals(mocks.submits.length, 2);
+});
+
 Deno.test('renderDeferredFrame composites sdf and volume raymarch passes after deferred lighting', () => {
   const mocks = createRenderMocks();
   const runtimeResidency = createRuntimeResidency();
@@ -1641,4 +1679,47 @@ Deno.test('renderDeferredFrame composites sdf and volume raymarch passes after d
     mocks.passActions.filter((action) => action.type === 'draw').length,
     5,
   );
+});
+
+Deno.test('renderDeferredFrame routes lighting through post-process when requested', () => {
+  const mocks = createRenderMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMesh(scene, {
+    id: 'mesh-deferred-post',
+    attributes: [
+      { semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] },
+      { semantic: 'NORMAL', itemSize: 3, values: [0, 0, 1, 0, 0, 1, 0, 0, 1] },
+    ],
+  });
+  scene = appendNode(scene, createNode('mesh-node', { meshId: 'mesh-deferred-post' }));
+
+  runtimeResidency.geometry.set('mesh-deferred-post', {
+    meshId: 'mesh-deferred-post',
+    attributeBuffers: {
+      POSITION: { id: 0 } as unknown as GPUBuffer,
+      NORMAL: { id: 1 } as unknown as GPUBuffer,
+    },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+
+  const result = renderDeferredFrame(
+    mocks as unknown as GpuRenderExecutionContext,
+    createOffscreenContext({
+      device: mocks.device as unknown as GPUDevice,
+      target: createHeadlessTarget(32, 32),
+    }),
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+    createMaterialRegistry(),
+    {
+      postProcessPasses: [createIdentityPostProcessPass('post:identity')],
+    },
+  );
+
+  assertEquals(result.drawCount, 4);
+  assertEquals(result.submittedCommandBufferCount, 2);
+  assertEquals(mocks.renderPassCount.current, 4);
+  assertEquals(mocks.submits.length, 2);
 });

--- a/tests/headless_snapshot_test.ts
+++ b/tests/headless_snapshot_test.ts
@@ -7,7 +7,11 @@ import {
   createRuntimeResidency,
 } from '@rieul3d/gpu';
 import { appendMaterial, appendMesh, appendNode, createNode, createSceneIr } from '@rieul3d/ir';
-import { renderDeferredSnapshot, renderForwardSnapshot } from '@rieul3d/renderer';
+import {
+  createIdentityPostProcessPass,
+  renderDeferredSnapshot,
+  renderForwardSnapshot,
+} from '@rieul3d/renderer';
 import { createHeadlessTarget } from '@rieul3d/platform';
 
 const createSnapshotMocks = () => {
@@ -204,6 +208,46 @@ Deno.test('renderForwardSnapshot also captures volume-only scenes with seeded re
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
   );
   assertEquals(mocks.submits.length, 2);
+});
+
+Deno.test('renderForwardSnapshot includes post-process execution before readback', async () => {
+  const mocks = createSnapshotMocks();
+  const runtimeResidency = createRuntimeResidency();
+  let scene = createSceneIr('scene');
+  scene = appendMesh(scene, {
+    id: 'mesh',
+    attributes: [{ semantic: 'POSITION', itemSize: 3, values: [0, 0, 0, 1, 0, 0, 0, 1, 0] }],
+  });
+  scene = appendNode(scene, createNode('node', { meshId: 'mesh' }));
+
+  runtimeResidency.geometry.set('mesh', {
+    meshId: 'mesh',
+    attributeBuffers: { POSITION: { id: 0 } as unknown as GPUBuffer },
+    vertexCount: 3,
+    indexCount: 0,
+  });
+
+  const binding = createOffscreenContext({
+    device: mocks.device as unknown as GPUDevice,
+    target: createHeadlessTarget(2, 2),
+  });
+
+  const snapshot = await renderForwardSnapshot(
+    mocks as unknown as Parameters<typeof renderForwardSnapshot>[0],
+    binding,
+    runtimeResidency,
+    evaluateScene(scene, { timeMs: 0 }),
+    undefined,
+    {
+      postProcessPasses: [createIdentityPostProcessPass('post:identity')],
+    },
+  );
+
+  assertEquals(snapshot.drawCount, 2);
+  assertEquals(snapshot.submittedCommandBufferCount, 2);
+  assertEquals(mocks.submits.length, 3);
+  assertEquals(snapshot.width, 2);
+  assertEquals(snapshot.height, 2);
 });
 
 Deno.test('renderDeferredSnapshot returns compact offscreen bytes for minimal deferred scenes', async () => {

--- a/tests/renderer_test.ts
+++ b/tests/renderer_test.ts
@@ -14,6 +14,7 @@ import {
   collectRendererCapabilityIssues,
   createDeferredRenderer,
   createForwardRenderer,
+  createIdentityPostProcessPass,
   createMaterialRegistry,
   extractDirectionalLightItems,
   extractSdfPassItems,
@@ -201,6 +202,25 @@ Deno.test('forward renderer omits raymarch pass when scene has no sdf or volume 
   );
 
   assertEquals(frame.passes.map((pass) => pass.id), ['mesh', 'present']);
+});
+
+Deno.test('frame planning inserts post-process passes before present', () => {
+  const frame = planFrame(
+    createForwardRenderer(),
+    evaluateScene(createSceneIr('scene'), { timeMs: 0 }),
+    createRuntimeResidency(),
+    {
+      postProcessPasses: [createIdentityPostProcessPass('post:identity')],
+    },
+  );
+
+  assertEquals(frame.passes.map((pass) => pass.id), ['mesh', 'post:identity', 'present']);
+  assertEquals(frame.passes[1], {
+    id: 'post:identity',
+    kind: 'post-process',
+    reads: ['color'],
+    writes: ['post-process:post:identity'],
+  });
 });
 
 Deno.test('deferred renderer plans only the implemented mesh passes', () => {


### PR DESCRIPTION
## Summary
- add a renderer-owned post-process pass contract with a built-in identity/blit helper
- route forward/deferred output and headless snapshots through an optional fullscreen pass chain
- document the new execution boundary and cover planning/render/snapshot behavior in tests

Closes #135

## Verification
- deno test -A --unstable-raw-imports tests/renderer_test.ts tests/forward_render_test.ts tests/headless_snapshot_test.ts
- deno task check
- deno task docs:check