### PR TITLE
renderer: key post-process pipelines by shader identity

### DIFF
--- a/docs/specs/rendering.md
+++ b/docs/specs/rendering.md
@@ -119,6 +119,8 @@ The initial renderer uses a lightweight pass graph:
 - Post-process programs reserve `@group(0) @binding(0)` for the input color texture and
   `@group(0) @binding(1)` for the input sampler; programs that opt into uniforms also reserve
   `@group(0) @binding(2)` for a uniform buffer.
+- Post-process pipeline residency is keyed by effective program identity, including WGSL, fragment
+  entry point, and uniform-buffer usage, so shader swaps do not silently reuse stale pipelines.
 - Deferred custom WGSL programs that register with `usesTransformBindings: true` should match the
   deferred `@group(0)` transform contract: evaluated node world matrix plus inverse-transpose normal
   matrix.

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -573,6 +573,17 @@ const cubemapFaceDescriptorByFace = new Map(
 const clampNumber = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
 
+const hashString = (value: string): string => {
+  let hash = 2166136261;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};
+
 const createRgbaBuffer = (width: number, height: number): Uint8Array =>
   new Uint8Array(width * height * 4);
 
@@ -2171,7 +2182,12 @@ export const ensurePostProcessPipeline = (
   program: PostProcessProgram,
   format: GPUTextureFormat,
 ): GPURenderPipeline => {
-  const cacheKey = `${program.id}:${format}`;
+  const programSignature = hashString(
+    `${program.wgsl}\n${program.fragmentEntryPoint}\n${
+      program.usesUniformBuffer ? 'uniform' : 'nouniform'
+    }`,
+  );
+  const cacheKey = `${program.id}:${format}:${programSignature}`;
   const cached = residency.pipelines.get(cacheKey);
   if (cached) {
     return cached as GPURenderPipeline;

--- a/tests/forward_render_test.ts
+++ b/tests/forward_render_test.ts
@@ -14,7 +14,9 @@ import {
   createMaterialRegistry,
   ensureBuiltInForwardPipeline,
   ensureMaterialPipeline,
+  ensurePostProcessPipeline,
   type GpuRenderExecutionContext,
+  type PostProcessProgram,
   registerWgslMaterial,
   renderDeferredFrame,
   renderForwardFrame,
@@ -284,6 +286,69 @@ Deno.test('ensureBuiltInForwardPipeline caches the generated pipeline', () => {
   assertStrictEquals(first, second);
   assertEquals(mocks.pipelines.length, 1);
   assertEquals(mocks.shaders.length, 1);
+});
+
+Deno.test('ensurePostProcessPipeline rebuilds cache entries when shader identity changes', () => {
+  const runtimeResidency = createRuntimeResidency();
+  const mocks = createRenderMocks();
+  const baseProgram: PostProcessProgram = {
+    id: 'post-process:test',
+    label: 'Post Process Test',
+    wgsl: `
+struct VsOut {
+  @builtin(position) position: vec4<f32>,
+};
+
+@vertex
+fn vsMain(@builtin(vertex_index) index: u32) -> VsOut {
+  var out: VsOut;
+  out.position = vec4<f32>(f32(index), 0.0, 0.0, 1.0);
+  return out;
+}
+
+@fragment
+fn fsMain() -> @location(0) vec4<f32> {
+  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+`,
+    fragmentEntryPoint: 'fsMain',
+  };
+
+  const first = ensurePostProcessPipeline(
+    mocks as unknown as GpuRenderExecutionContext,
+    runtimeResidency,
+    baseProgram,
+    'rgba8unorm',
+  );
+  const same = ensurePostProcessPipeline(
+    mocks as unknown as GpuRenderExecutionContext,
+    runtimeResidency,
+    baseProgram,
+    'rgba8unorm',
+  );
+  const changedShader = ensurePostProcessPipeline(
+    mocks as unknown as GpuRenderExecutionContext,
+    runtimeResidency,
+    {
+      ...baseProgram,
+      wgsl: baseProgram.wgsl.replace('1.0, 0.0, 0.0, 1.0', '0.0, 1.0, 0.0, 1.0'),
+    },
+    'rgba8unorm',
+  );
+  const changedLayout = ensurePostProcessPipeline(
+    mocks as unknown as GpuRenderExecutionContext,
+    runtimeResidency,
+    {
+      ...baseProgram,
+      usesUniformBuffer: true,
+    },
+    'rgba8unorm',
+  );
+
+  assertStrictEquals(first, same);
+  assertEquals(first === changedShader, false);
+  assertEquals(changedShader === changedLayout, false);
+  assertEquals(mocks.pipelines.length, 3);
 });
 
 Deno.test('renderForwardFrame encodes indexed and non-indexed draws from mesh residency', () => {


### PR DESCRIPTION
## Summary
- key post-process pipeline residency by effective shader identity instead of program id alone
- add a regression test covering WGSL and uniform-layout changes under the same post-process id
- document the cache-key behavior in the rendering spec

## Context
- closed superseded PR #136 because the shipped post-process API on main had already diverged
- closed issue #135 because the minimal post-process contract is already present on main
- this PR addresses the remaining follow-up bug tracked in #137

Closes #137

## Verification
- deno fmt packages/renderer/src/renderer.ts tests/forward_render_test.ts docs/specs/rendering.md
- deno test -A --unstable-raw-imports tests/forward_render_test.ts tests/renderer_test.ts tests/headless_snapshot_test.ts