### PR TITLE
docs: refresh React integration guides

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -17,7 +17,8 @@ source of truth for package boundaries and feature expectations.
 - [`cubemap-export.md`](./cubemap-export.md): CPU-side reprojection/export layouts built on captured
   cubemap faces
 - [`interaction.md`](./interaction.md): screen-to-world interaction ray construction
-- [`react-authoring.md`](./react-authoring.md): React package role and lowering boundaries
+- [`react-authoring.md`](./react-authoring.md): React package role, snapshot bridge, and
+  experimental reconciler boundaries
 
 ## Runtime Behavior
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ Runnable examples live here. Each example should document how to build, serve, o
   including the Stanford Bunny PLY source mesh
 - [`browser_forward/README.md`](./browser_forward/README.md): browser-based forward rendering flow
 - [`browser_react_authoring/README.md`](./browser_react_authoring/README.md): browser forward flow
-  with scene nodes authored through `@rieul3d/react` TSX
+  with scene nodes authored through `@rieul3d/react` TSX and committed through the snapshot bridge
 - [`browser_textured_forward/README.md`](./browser_textured_forward/README.md): browser forward flow
   with uploaded texture residency and built-in unlit sampling
 - [`browser_custom_textured_forward/README.md`](./browser_custom_textured_forward/README.md):
@@ -64,6 +64,13 @@ The BYOW primitives demo and the BYOW React Bunny demo both show the current cam
 attach a perspective camera to a node, mark it as the scene's active camera, and render through the
 standard forward renderer. The React Bunny demo now drives that scene path through the experimental
 reconciler host instead of the snapshot-only JSX lowering helper.
+
+For React integrations, read the examples in this order:
+
+- [`browser_react_authoring/README.md`](./browser_react_authoring/README.md) for the data-only
+  `createSceneRoot()` snapshot bridge
+- [`byow_react_bunny_demo/README.md`](./byow_react_bunny_demo/README.md) for the experimental
+  `@rieul3d/react/reconciler` live host
 
 ## Related Docs
 

--- a/examples/browser_react_authoring/README.md
+++ b/examples/browser_react_authoring/README.md
@@ -10,16 +10,20 @@ GPU residency can drop changed mesh/material/texture/volume entries by ID, keep 
 updates on the lighter path, include unchanged descendants whose world transforms moved under an
 updated ancestor, and still fall back to a full reset for node topology or binding changes.
 
-The example now follows ADR 0005's preferred direction: camera/light convenience lives in reusable
-React components while primitive JSX authoring stays closer to explicit Scene IR concepts such as
-`<camera>`, `<light>`, and `<node>`.
+The example follows ADR 0005's preferred direction: camera/light convenience lives in reusable React
+components while primitive JSX authoring stays closer to explicit Scene IR concepts such as
+`<camera>`, `<light>`, and `<node>`. It intentionally documents the snapshot path, not the live
+reconciler path.
 
-This is now a real JSX authoring example with the current snapshot-based `createSceneRoot()` path,
-but it is still not a live React renderer or reconciler. `@rieul3d/react` currently owns authoring,
-snapshot commits, and subscription only.
+`@rieul3d/react` now has two distinct integration surfaces:
 
-Longer term, this package should move toward a `react-three-fiber`-style interface where
-reconciliation updates rieul3d's runtime over time instead of lowering the tree only once.
+- `createSceneRoot()` for JSX authoring plus snapshot commits, summaries, and targeted update
+  planning
+- `@rieul3d/react/reconciler` for the experimental live React host that publishes committed
+  `SceneIr` snapshots from normal React state and lifecycle updates
+
+If you want the live reconciler path instead of the snapshot bridge, use the BYOW React Bunny demo
+as the current reference example.
 
 Build the example bundle:
 
@@ -42,6 +46,7 @@ http://localhost:8000/examples/browser_react_authoring/index.html
 Related references:
 
 - [`../../examples/README.md`](../README.md)
+- [`../byow_react_bunny_demo/README.md`](../byow_react_bunny_demo/README.md)
 - [`../../docs/specs/react-authoring.md`](../../docs/specs/react-authoring.md)
 - [`../../docs/adr/0004-react-jsx-authoring.md`](../../docs/adr/0004-react-jsx-authoring.md)
 - [`../../docs/specs/rendering.md`](../../docs/specs/rendering.md)


### PR DESCRIPTION
## Summary
- clarify that the browser React authoring example documents the snapshot createSceneRoot() path
- point React readers at the BYOW bunny example for the experimental @rieul3d/react/reconciler live host
- update spec/example index pages so snapshot and live React integration surfaces are easier to discover

## Verification
- deno task docs:check

Closes #139